### PR TITLE
Bug fixing in running test plus grep

### DIFF
--- a/pyworkflow/apps/pw_run_tests.py
+++ b/pyworkflow/apps/pw_run_tests.py
@@ -240,8 +240,8 @@ class Tester:
             spaces = (itemType * 2) * ' '
             script = getTestsScript()
             cmd = "%s %s %s" % (script, spaces, itemName)
-            run = ((itemType == MODULE and self.mode == 'module') or
-                   (itemType == CLASS and self.mode == 'classes') or
+            run = ((itemType == MODULE and self.mode == 'modules') or
+                   (itemType == CLASS and self.mode in ('classes', 'onlyclasses')) or
                    (itemType == TEST and self.mode == 'all'))
             if run:
                 if self.log:


### PR DESCRIPTION
Before this PR, `--mode` and `--run` flags for test mode were incompatible (no test run) due to a couple of bugs that are fixed here.

Now, 

`scipion3 test --grep any-pattern-like-plugin-name --mode modules --run`

or

`scipion3 test --grep any-pattern-like-plugin-name --mode onlyclasses --run`

can be used. This is useful because without that modes every test is run twice (one for module one for class).