### PR TITLE
form --> self.enum.choices is an object of type odict_values, which c…

### DIFF
--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -312,7 +312,9 @@ class ComboVar:
     def set(self, value):
         self.value = value
         if isinstance(value, int):
-            self.tkVar.set(self.enum.choices[value])
+            # self.enum.choices is an object of type odict_values, which
+            # cannot be indexed, so a type cast to list is required
+            self.tkVar.set(list(self.enum.choices)[value])
         else:
             self.tkVar.set(value)  # also support string values
                     

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -321,7 +321,7 @@ class ComboVar:
     def get(self):
         v = self.tkVar.get()
         self.value = None
-        for i, c in enumerate(self.enum.choices):
+        for i, c in enumerate(list(self.enum.choices)):
             if c == v:
                 self.value = i
             

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -1301,7 +1301,7 @@ class ParamWidget:
         selected = []
         if isinstance(value, list):
             selected = value
-        elif selected is not None:
+        elif selected:
             selected = [value]
         tp = SubclassesTreeProvider(self._protocol, self.param,
                                     selected=selected)
@@ -1341,7 +1341,7 @@ class ParamWidget:
         selected = []
         if isinstance(value, list):
             selected = value
-        elif selected is not None:
+        elif selected:
             selected = [value]
         tp = ScalarTreeProvider(self._protocol, self.param,
                                 selected=selected)

--- a/pyworkflow/gui/plotter.py
+++ b/pyworkflow/gui/plotter.py
@@ -184,6 +184,7 @@ class Plotter(View):
         self.tightLayoutOn = False
         cax = self.figure.add_axes([0.9, 0.1, 0.03, 0.8])
         cbar = self.figure.colorbar(plot, cax=cax)
+        cbar.set_ticks(cbar.get_ticks())
         cbar.ax.invert_yaxis()
 
     def tightLayout(self):


### PR DESCRIPTION
…annot be indexed, so a type cast to list is required.

plotter has the tick values but didn't show them after the migration to python3.