### PR TITLE
aovid projects with .json in the name, requirements relaxed

### DIFF
--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -1813,7 +1813,7 @@ class FormWindow(Window):
                 self.useGpuVar.trace('w', self._setGpu)
                 self.gpuListVar.trace('w', self._setGpu)
         except Exception as e:
-            print("Parallel section couldn't be created. %s" % e.message)
+            print("Parallel section couldn't be created. %s" % e)
 
     def _createCommon(self, parent):
         """ Create the second section with some common parameters. """

--- a/pyworkflow/template.py
+++ b/pyworkflow/template.py
@@ -11,7 +11,8 @@ from pyworkflow.utils import greenStr
 class Template:
     def __init__(self, pluginName, tempPath):
         self.pluginName = pluginName
-        self.templateName = os.path.basename(tempPath).replace(SCIPION_JSON_TEMPLATES, "")
+        # Tidy up templates names: removing .json.template and .json (when passed as parameter)
+        self.templateName = os.path.basename(tempPath).replace(SCIPION_JSON_TEMPLATES, "").replace(".json","")
         self.templatePath = os.path.abspath(tempPath)
         self.description, self.content = self._parseTemplate()
         self.params = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-bibtexparser==1.2.0
-psutil==5.7.0
-configparser==5.0.0
-matplotlib==3.2.2
-numpy==1.18.4
-pillow==7.1.2
-requests==2.23.0
+bibtexparser<=1.2.0
+psutil<=5.7.0
+configparser<=5.0.0
+matplotlib<=3.2.2
+numpy<=1.18.4
+pillow<=7.1.2
+requests<=2.23.0


### PR DESCRIPTION
This PR:
Closes #128 (avoid .json in project names)
Relaxes requirements.txt to allow python3.5 installations (matplotlib and configparser were not compatible)
Close #123 : Removes e.message use.