### PR TITLE
Close the mapper when stopping a protocol.

### DIFF
--- a/pyworkflow/object.py
+++ b/pyworkflow/object.py
@@ -887,7 +887,7 @@ class Pointer(Object):
             return []
     
     def setExtendedParts(self, parts):
-        """ Set the extedend attribute but using 
+        """ Set the extended attribute but using
         a list as input. 
         """
         self.setExtended('.'.join(parts))
@@ -1116,7 +1116,9 @@ class Set(OrderedObject):
         
     def __getitem__(self, itemId):
         """ Get the image with the given id. """
-        return self._getMapper().selectById(itemId)
+        item = self._getMapper().selectById(itemId)
+        self.close()
+        return item
 
     def __contains__(self, itemId):
         """ element in Set """

--- a/pyworkflow/project/project.py
+++ b/pyworkflow/project/project.py
@@ -761,6 +761,7 @@ class Project(object):
             protocol.setMapper(self.createMapper(protocol.getDbPath()))
             protocol._store()
             self._storeProtocol(protocol)
+            protocol.getMapper().close()
 
     def resetProtocol(self, protocol):
         """ Stop a running protocol """


### PR DESCRIPTION
Close the mapper in Sets after __getItem__

This are some changes that avoid locking sqlite files.

1.- when stopping a protocol
2.- when using a Set.__getItem__

I've tested this and locks are gone.

Since this is very deep in the core, I'd like to have your comments @delarosatrevin before moving forward. I'm saving this as a draft.

All this was triggered by #116 .