### PR TITLE
Fixes when MANDATORY is in the host.conf and MPI/cores are above MAND…

### DIFF
--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -1974,6 +1974,7 @@ class FormWindow(Window):
             result = dlg.value
         
         self.protocol.setQueueParams(result)
+        self.protocol.queueShown = True
         return True
 
     def _createParams(self, parent):
@@ -2156,7 +2157,7 @@ class FormWindow(Window):
 
     def _getQueueReady(self):
         """ Check if queue is active, if so ask for params if missing"""
-        if self.protocol.hasQueueParams():
+        if self.protocol.hasQueueParams() and self.protocol.queueShown:
             return True
         else:
             return self._editQueueParams()

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -2148,22 +2148,24 @@ class FormWindow(Window):
         self._close(onlySave=True)
 
     def schedule(self):
-        if not self._getQueueReady():
-            return
+        if self.protocol.useQueue():
+            if not self._getQueueReady():
+                return
 
         self._close(doSchedule=True)
 
     def _getQueueReady(self):
         """ Check if queue is active, if so ask for params if missing"""
-        if self.protocol.useQueue() and not self.protocol.hasQueueParams():
+        if self.protocol.hasQueueParams():
+            return True
+        else:
             return self._editQueueParams()
-
-        return True
 
     def execute(self, e=None):
 
-        if not self._getQueueReady():
-            return
+        if self.protocol.useQueue():
+            if not self._getQueueReady():
+                return
         else:  # use queue = No
             hostConfig = self._getHostConfig()
             cores = self.protocol.numberOfMpi.get(1) * self.protocol.numberOfThreads.get(1)

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -390,6 +390,7 @@ class Protocol(Step):
         # Store a json string with queue name
         # and queue parameters (only meaningful if _useQueue=True)
         self._queueParams = String()
+        self.queueShown = False
         self._jobId = String()  # Store queue job id
         self._pid = Integer()
         self._stepsExecutor = None


### PR DESCRIPTION
…ATORY.

This should fix what @delarosatrevin reported today in slack. 

Prevoius code wasn't distinguishing between:

1.- useQueue = True and Queueparams populated
2.- useQueue = False (therefore else was never happening)

I do not have a queue engine locally to test this.