### PR TITLE
Project: has a new method to clean a project name, so far it just rep…

### DIFF
--- a/pyworkflow/apps/pw_project.py
+++ b/pyworkflow/apps/pw_project.py
@@ -52,6 +52,11 @@ def openProject(projectName):
     # from the current directory
     if projName == 'here':
         cwd = Config.SCIPION_CWD
+
+        if " " in cwd:
+            print("Projects can't have spaces in the name: %s" % cwd)
+            sys.exit(1)
+
         print("\nYou are trying to create a project here:",
               pwutils.cyan(cwd))
 
@@ -66,7 +71,7 @@ def openProject(projectName):
             print("\nCreating project....")
             projName = os.path.basename(cwd)
             projDir = os.path.dirname(cwd)
-            proj = manager.createProject(projName, location=projDir)
+            manager.createProject(projName, location=projDir)
 
     elif projName == 'last':  # Get last project
         projects = manager.listProjects()

--- a/pyworkflow/constants.py
+++ b/pyworkflow/constants.py
@@ -40,7 +40,7 @@ VERSION_1 = '1.0.0'
 VERSION_1_1 = '1.1.0'
 VERSION_1_2 = '1.2.0'
 VERSION_2_0 = '2.0.0'
-VERSION_3_0 = '3.0.7'
+VERSION_3_0 = '3.0.8'
 
 # For a new release, define a new constant and assign it to LAST_VERSION
 # The existing one has to be added to OLD_VERSIONS list.

--- a/pyworkflow/gui/project/viewprojects.py
+++ b/pyworkflow/gui/project/viewprojects.py
@@ -169,9 +169,9 @@ class ProjectsView(tk.Frame):
         return frame
 
     def createNewProject(self, projName, projLocation):
-        self.manager.createProject(projName, location=projLocation)
+        proj = self.manager.createProject(projName, location=projLocation)
         self.createProjectList(self.text)
-        self.openProject(projName)
+        self.openProject(proj.getShortName())
 
     def _onCreateProject(self, e=None):
         projWindow = ProjectCreateWindow("Create project", self)
@@ -250,29 +250,32 @@ class ProjectCreateWindow(Window):
         content.config(bg='white')
         content.grid(row=0, column=0, sticky='news', padx=5, pady=5)
 
+        # Info line
+        labelInfo = tk.Label(content, text="Spaces will be replaced by underscores!" , bg='white', bd=0)
+        labelInfo.grid(row=0, sticky=tk.W, padx=5, pady=5)
         #  Project name line
         labelName = tk.Label(content, text=Message.LABEL_PROJECT + ' name', bg='white', bd=0)
-        labelName.grid(row=0, sticky=tk.W, padx=5, pady=5)
+        labelName.grid(row=1, sticky=tk.W, padx=5, pady=5)
         entryName = tk.Entry(content, bg=cfgEntryBgColor, width=20, textvariable=self.projName)
-        entryName.grid(row=0, column=1, columnspan=2, sticky=tk.W, padx=5, pady=5)
+        entryName.grid(row=1, column=1, columnspan=2, sticky=tk.EW, padx=5, pady=5)
         entryName.bind("<Return>", self._create)
         entryName.bind("<KP_Enter>", self._create)
         # Project location line
         labelLocation = tk.Label(content, text=Message.LABEL_PROJECT + ' location', bg='white', bd=0)
-        labelLocation.grid(row=1, column=0, sticky='nw', padx=5, pady=5)
+        labelLocation.grid(row=2, column=0, sticky='nw', padx=5, pady=5)
 
         self.entryBrowse = tk.Entry(content, bg=cfgEntryBgColor, width=40, textvariable=self.projLocation)
-        self.entryBrowse.grid(row=1, column=1, sticky='nw', padx=5, pady=5)
+        self.entryBrowse.grid(row=2, column=1, sticky='nw', padx=5, pady=5)
         self.btnBrowse = IconButton(content, 'Browse', Icon.ACTION_BROWSE,
                                     highlightthickness=0, command=self._browsePath)
-        self.btnBrowse.grid(row=1, column=2, sticky='e', padx=5, pady=5)
+        self.btnBrowse.grid(row=2, column=2, sticky='e', padx=5, pady=5)
 
         self.initial_focus = entryName
         self.initial_focus.focus()
 
         btnFrame = tk.Frame(content)
         btnFrame.columnconfigure(0, weight=1)
-        btnFrame.grid(row=2, column=0, sticky='sew', padx=5, pady=(0, 5), columnspan=2)
+        btnFrame.grid(row=3, column=0, sticky='sew', padx=5, pady=(0, 5), columnspan=2)
         btnFrame.config(bg='white')
 
         # Create buttons

--- a/pyworkflow/project/manager.py
+++ b/pyworkflow/project/manager.py
@@ -88,6 +88,9 @@ class Manager(object):
         confs dict can contains customs .conf files 
         for: menus, protocols, or hosts
         """
+        # Clean project name from undesired characters
+        projectName = Project.cleanProjectName(projectName)
+
         # If location is not None create project on it (if exists)
         if location is None:
             projectPath = self.getProjectPath(projectName)

--- a/pyworkflow/project/project.py
+++ b/pyworkflow/project/project.py
@@ -1666,6 +1666,13 @@ class Project(object):
                                       pwutils.green("   %s -> %s" % (f, newFile)))
                                 pwutils.createAbsLink(newFile, f)
 
+    @staticmethod
+    def cleanProjectName(projectName):
+        """ Cleans a project name to avoid common errors
+        Use it whenever you want to get the final project name pyworkflow will endup.
+        Spaces will be replaced by _ """
+        return projectName.replace(" ", "_")
+
 
 class MissingProjectDbException(Exception):
     pass

--- a/pyworkflow/project/scripts/edit_workflow.py
+++ b/pyworkflow/project/scripts/edit_workflow.py
@@ -69,7 +69,7 @@ manager = Manager(workspace=customUserData)
 
 projName = os.path.basename(jsonFn)
 proj = manager.createProject(projName)
-projPath = manager.getProjectPath(projName)
+projPath = manager.getProjectPath(proj.getShortName())
 proj.loadProtocols(jsonFn)
 
 

--- a/pyworkflow/project/scripts/schedule.py
+++ b/pyworkflow/project/scripts/schedule.py
@@ -27,6 +27,7 @@
 
 import sys
 import os
+import time
 
 import pyworkflow as pw
 from pyworkflow.project import Manager
@@ -91,6 +92,8 @@ for prot in runs:
     if (protClassName not in sys.argv[3:] and
             protLabelName not in sys.argv[3:]):
         project.scheduleProtocol(prot)
+        # Wait 1 seconds to avoid concurrent activity
+        time.sleep(0.7)
     else:
         print(pwutils.blueStr("\nNot scheduling '%s' protocol named '%s'.\n"
                               % (protClassName, protLabelName)))


### PR DESCRIPTION
…laces " " by "_"

manager.py uses the new method
"here" mode fails if folder has spaces.
createNewProject window takes into account the renaming and informs about it (label)
schedule script waits between protocols (feels more responsive)
version bumped