### PR TITLE
Fix "wait for" and visualize schedule.log

### DIFF
--- a/pyworkflow/apps/pw_schedule_run.py
+++ b/pyworkflow/apps/pw_schedule_run.py
@@ -88,11 +88,11 @@ class RunScheduler:
         protocol = self._loadProtocol()
         mapper = protocol.getMapper()
 
-        log = open(protocol._getLogsPath('schedule.log'), 'w')
+        log = open(protocol.getScheduleLog(), 'w')
         pid = os.getpid()
         protocol.setPid(pid)
 
-        prerequisites = map(int, protocol.getPrerequisites())
+        prerequisites = list(map(int, protocol.getPrerequisites()))
 
         def _log(msg):
             log.write("%s: %s\n" % (prettyTimestamp(), msg))
@@ -108,12 +108,18 @@ class RunScheduler:
         # Keep track of the last time the protocol was checked and
         # its modification date to avoid unnecessary db opening
         lastCheckedDict = {}
+        updatedProtocols = []
 
         def _updateProtocol(protocol, project):
+
+            protId = protocol.getObjId()
+
+            if protId in updatedProtocols:
+                return
+
             protDb = protocol.getDbPath()
 
             if os.path.exists(protDb):
-                protId = protocol.getObjId()
                 lastChecked = lastCheckedDict.get(protId, None)
                 lastModified = getFileLastModificationDate(protDb)
 
@@ -121,6 +127,7 @@ class RunScheduler:
                     project._updateProtocol(protocol,
                                             skipUpdatedProtocols=False)
                     _log("Updated protocol %s" % protId)
+                    updatedProtocols.append(protId)
 
         def _getProtocolFromPointer(pointer):
             """
@@ -156,6 +163,9 @@ class RunScheduler:
             # Check if there are input protocols failed or aborted
             failedInputProtocols = False
 
+            # Clear the list of protocols updated in the previous loop
+            updatedProtocols.clear()
+
             _log("Checking input data...")
             # FIXME: This does not cover all the cases:
             # When the user registers new coordinates after clicking the
@@ -174,7 +184,7 @@ class RunScheduler:
                 _updateProtocol(protocol, project)
                 validation = protocol.validate()
                 if len(validation) > 0:
-                    missing = True
+                    missing  = True
                     _log("%s doesn't validate:\n\t- %s"
                          % (protocol.getObjLabel(),
                             '\n\t- '.join(validation)))
@@ -193,7 +203,8 @@ class RunScheduler:
                     for prot in inputProtocolDict.values():
                         _updateProtocol(prot, project)
 
-            _log("Checking prerequisites...")
+            _log("Checking prerequisites... %s" % prerequisites)
+
             wait = False  # Check if we need to wait for required protocols
             for protId in prerequisites:
                 prot = project.getProtocol(protId)

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -1788,9 +1788,11 @@ class ProtocolsView(tk.Frame):
             self.outputViewer.clear()
             # Right now skip the err tab since we are redirecting
             # stderr to stdout
-            out, _, log = prot.getLogPaths()
+            out, _, log, schedule = prot.getLogPaths()
             self.outputViewer.addFile(out)
             self.outputViewer.addFile(log)
+            if os.path.exists(schedule):
+                self.outputViewer.addFile(schedule)
             self.outputViewer.setIndex(i)  # Preserve the last selected tab
             self.outputViewer.selectedText().goEnd()
             # when there are not logs, force re-load next time
@@ -2039,6 +2041,8 @@ class ProtocolsView(tk.Frame):
                     self._exportProtocols(defaultPath=browser.getCurrentDir(),
                                           defaultBasename=browser.getEntryValue())
             except Exception as ex:
+                import traceback
+                traceback.print_exc()
                 self.windows.showError(str(ex))
 
         browser = pwgui.browser.FileBrowserWindow(
@@ -2182,7 +2186,7 @@ class ProtocolsView(tk.Frame):
                 elif action == ACTION_RESULTS:
                     self._analyzeResults(prot)
                 elif action == ACTION_EXPORT:
-                    self._exportProtocols()
+                    self._exportProtocols(defaultPath=pwutils.getHomePath())
                 elif action == ACTION_EXPORT_UPLOAD:
                     self._exportUploadProtocols()
                 elif action == ACTION_COLLAPSE:

--- a/pyworkflow/project/project.py
+++ b/pyworkflow/project/project.py
@@ -964,7 +964,10 @@ class Project(object):
                 matches.append((oKey, iKey))
             else:
                 for oKey, oAttr in node.run.iterOutputAttributes():
-                    if oAttr.getObjId() == iAttr.get().getObjId():
+                    # If node output is "real" and iAttr is still just a pointer
+                    # the iAttr.get() will return None
+                    pointed = iAttr.get()
+                    if pointed is not None and oAttr.getObjId() == pointed.getObjId():
                         matches.append((oKey, iKey))
 
         return matches

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -39,6 +39,8 @@ from .executor import (StepExecutor, ThreadStepExecutor, MPIStepExecutor,
 from .constants import *
 from .params import Form
 
+SCHEDULE_LOG = 'schedule.log'
+
 
 class Step(OrderedObject):
     """ Basic execution unit.
@@ -1415,7 +1417,10 @@ class Protocol(Step):
 
     def getLogPaths(self):
         return list(map(self._getLogsPath,
-                        ['run.stdout', 'run.stderr', 'run.log']))
+                        ['run.stdout', 'run.stderr', 'run.log', SCHEDULE_LOG]))
+
+    def getScheduleLog(self):
+        return self._getLogsPath(SCHEDULE_LOG)
 
     def getSteps(self):
         """ Return the steps.sqlite file under logs directory. """


### PR DESCRIPTION
Visualize schedule.log if exists.
Fix workflow export error: https://github.com/scipion-em/scipion-pyworkflow/issues/158
Export browse window starts at home.
Schedule: fix "wait for" not working. Avoid updating protocols twice in the same loop (when prerequisites existed)
Closes #158 