### PR TITLE
Add VS Code as possible editor and open html files in browser.

### DIFF
--- a/pyworkflow/gui/text.py
+++ b/pyworkflow/gui/text.py
@@ -62,7 +62,7 @@ elif os.name == 'posix':  # linux systems and so on
 
     x_open = find_prog('xdg-open', 'gnome-open', 'kde-open', 'gvfs-open')
     editor = find_prog('pluma', 'gedit', 'kwrite', 'geany', 'kate',
-                       'emacs', 'nedit', 'mousepad')
+                       'emacs', 'nedit', 'mousepad', 'code')
 
     def _open_cmd(path, tkParent=None):
         # If it is an url, open with browser.

--- a/pyworkflow/gui/text.py
+++ b/pyworkflow/gui/text.py
@@ -66,7 +66,7 @@ elif os.name == 'posix':  # linux systems and so on
 
     def _open_cmd(path, tkParent=None):
         # If it is an url, open with browser.
-        if path.startswith('http://') or path.startswith('https://'):
+        if path.startswith('http://') or path.startswith('https://') or path.endswith('.html'):
             try:
                 webbrowser.open_new_tab(path)
                 return


### PR DESCRIPTION
For scipion-ed it is sometimes useful to open html output files from the "browse" option in the GUI. Treating html files the same way as any url fixes this.

I also noticed that my preferred editor was not available in the list, so I added it.