### PR TITLE
Do not parse bibtex at module init

### DIFF
--- a/pyworkflow/plugin.py
+++ b/pyworkflow/plugin.py
@@ -81,10 +81,13 @@ class Domain:
         m._bibtex = {}
         bib = cls.__getSubmodule(name, 'bibtex')
         if bib is not None:
-            try:
-                m._bibtex = pwutils.parseBibTex(bib.__doc__)
-            except Exception:
-                pass
+            if hasattr(bib, "_bibtex"):
+                print("WARNING FOR DEVELOPERS:  %s/%s._bibtex unnecessarily declared. Just the doc string is enough." % (name, "bibtex"))
+            else:
+                try:
+                    m._bibtex = pwutils.LazyDict(lambda :pwutils.parseBibTex(bib.__doc__))
+                except Exception:
+                    pass
         cls._plugins[name] = m  # Register the name to as a plugin
 
     @classmethod

--- a/pyworkflow/protocol/bibtex.py
+++ b/pyworkflow/protocol/bibtex.py
@@ -25,11 +25,6 @@
 # *
 # **************************************************************************
 """
-Bibtex string file for Scipion package.
-"""
-
-_bibtexStr = """
-
 @article{delaRosaTrevin201693,
 title = "Scipion: A software framework toward integration, reproducibility and validation in 3D electron microscopy ",
 journal = "Journal of Structural Biology",
@@ -51,7 +46,3 @@ keywords = "Reproducibility "
 }
 """
 
-
-from pyworkflow.utils import parseBibTex
-
-_bibtex = parseBibTex(_bibtexStr)  

--- a/pyworkflow/utils/utils.py
+++ b/pyworkflow/utils/utils.py
@@ -29,6 +29,7 @@ from datetime import datetime
 import traceback
 from enum import Enum
 
+import bibtexparser
 import numpy as np
 import math
 
@@ -475,24 +476,41 @@ def parseHyperText(text, matchCallback):
 #
 #    return text
 
+class LazyDict(object):
+    """ Dictionary to be initialized in the moment it is accessed for the first time.
+    Initialization is done by a callback passed at instantiation"""
+    def __init__(self, callback=dict):
+        """ :param callback: method to initialize the dictionary. SHould return a dictionary"""
+        self.data = None
+        self.callback = callback
+
+    def evaluate_callback(self):
+        self.data = self.callback()
+
+    def __getitem__(self, name):
+        if (self.data is None):
+            self.evaluate_callback()
+        return self.data.__getitem__(name)
+
+    def __setitem__(self, name, value):
+        if (self.data is None):
+            self.evaluate_callback()
+        return self.data.__setitem__(name, value)
+
+    def __getattr__(self, name):
+        if (self.data is None):
+            self.evaluate_callback()
+        return getattr(self.data, name)
+    def __iter__(self):
+        if (self.data is None):
+            self.evaluate_callback()
+        return self.data.__iter__()
 
 def parseBibTex(bibtexStr):
     """ Parse a bibtex file and return a dictionary. """
-    import bibtexparser
 
-    if hasattr(bibtexparser, 'loads'):
-        return bibtexparser.loads(bibtexStr).entries_dict
+    return bibtexparser.loads(bibtexStr).entries_dict
 
-    # For older bibtexparser version 0.5
-    from bibtexparser.bparser import BibTexParser
-    from io import StringIO
-
-    f = StringIO()
-    f.write(bibtexStr)
-    f.seek(0, 0)
-    parser = BibTexParser(f)
-
-    return parser.bib_database.get_entry_dict()
 
 
 def isPower2(num):


### PR DESCRIPTION
Lazy initialization dictionary class
Used for _bibtex dictionaries.
Removed old bibtex parsing code (0.5)
Dev warining: in case _bibtex present at "package" folder. Now is done deferred upon demand.