### PR TITLE
* Remove the folder related with the specific protocol within the scratch if it exists

### DIFF
--- a/pyworkflow/utils/path.py
+++ b/pyworkflow/utils/path.py
@@ -173,8 +173,10 @@ def makeTmpPath(protocol):
                 project = protocol.getProject()
                 folderId = "_".join([project.getShortName(),project.getProtWorkingDir(protocol)])
                 tmpScratchFolder = os.path.join(scratchPath, folderId)
+                if os.path.exists(tmpScratchFolder):
+                    cleanPath(tmpScratchFolder)
                 os.makedirs(tmpScratchFolder)  # Create scratch folder
-                createAbsLink(tmpScratchFolder, tmpPath)
+                createAbsLink(tmpScratchFolder, tmpPath)  # Create a sym link
 
             except Exception as e:
                 raise PyworkflowException("Couldn't create the temporary folder %s at:\n %s\nPlease, review %s variable." %


### PR DESCRIPTION
* Remove the folder related with the specific protocol within the scratch if it exists
  - This is a case when a test is launched and it fails or is aborted(the folder stays in the scratch)