### PR TITLE
Gpu chunk fix

### DIFF
--- a/pyworkflow/constants.py
+++ b/pyworkflow/constants.py
@@ -40,7 +40,7 @@ VERSION_1 = '1.0.0'
 VERSION_1_1 = '1.1.0'
 VERSION_1_2 = '1.2.0'
 VERSION_2_0 = '2.0.0'
-VERSION_3_0 = '3.0.8'
+VERSION_3_0 = '3.0.9'
 
 # For a new release, define a new constant and assign it to LAST_VERSION
 # The existing one has to be added to OLD_VERSIONS list.

--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -178,8 +178,7 @@ class ThreadStepExecutor(StepExecutor):
             else:
                 # Expand gpuList repeating until reach nThreads items
                 if nThreads > nGpu:
-                    import numpy as np
-                    newList = np.asarray(self.gpuList) * (nThreads/nGpu+1)
+                    newList = self.gpuList * (int(nThreads/nGpu)+1)
                     self.gpuList = newList[:nThreads]
 
                 for node, gpu in zip(nodes, self.gpuList):

--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -172,7 +172,7 @@ class ThreadStepExecutor(StepExecutor):
             nGpu = len(self.gpuList)
 
             if nGpu > nThreads:
-                chunk = nGpu / nThreads
+                chunk = int(nGpu / nThreads)
                 for i, node in enumerate(nodes):
                     self.gpuDict[node] = list(self.gpuList[i*chunk:(i+1)*chunk])
             else:


### PR DESCRIPTION
This fixes an issue reported by email, where user was setting several items in the GPUs and several mpis.

````
Traceback (most recent call last):
  File "/usr/local/apps/scipion/3.0.6/anaconda/envs/.scipion3env/lib/python3.8/site-packages/pyworkflow/apps/pw_protocol_mpirun.py", line 54, in <module>
    runProtocolMainMPI(projectPath, dbPath, protId, comm)
  File "/usr/local/apps/scipion/3.0.6/anaconda/envs/.scipion3env/lib/python3.8/site-packages/pyworkflow/protocol/protocol.py", line 2229, in runProtocolMainMPI
    executor = MPIStepExecutor(hostConfig, protocol.numberOfMpi.get() - 1,
  File "/usr/local/apps/scipion/3.0.6/anaconda/envs/.scipion3env/lib/python3.8/site-packages/pyworkflow/protocol/executor.py", line 342, in __init__
    ThreadStepExecutor.__init__(self, hostConfig, nMPI, **kwargs)
  File "/usr/local/apps/scipion/3.0.6/anaconda/envs/.scipion3env/lib/python3.8/site-packages/pyworkflow/protocol/executor.py", line 177, in __init__
    self.gpuDict[node] = list(self.gpuList[i*chunk:(i+1)*chunk])
TypeError: slice indices must be integers or None or have an __index__ method 

````

chunk reaches that point being a decimal number and not integer. Probably we missed this when migrating to python3.

I've tested this change in a 2 GPU machine and worked.