### PR TITLE
Review of protocol time (CPU time and Wall time)

### DIFF
--- a/pyworkflow/project/project.py
+++ b/pyworkflow/project/project.py
@@ -418,7 +418,7 @@ class Project(object):
                                     attr.write()
                                     attr.close()
                             protocol.setStatus(pwprot.STATUS_SAVED)
-                            protocol._setStatusSteps(pwprot.STATUS_SAVED)
+                            protocol._updateSteps(lambda step: step.setStatus(pwprot.STATUS_SAVED))
                             protocol.setMapper(self.createMapper(protocol.getDbPath()))
                             protocol._store()
                             self._storeProtocol(protocol)

--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -152,10 +152,10 @@ class StepThread(threading.Thread):
         finally:
             with self.lock:
                 if error is None:
-                    self.step.setStatus(cts.STATUS_FINISHED)
+                    self.step.setFinished()
                 else:
                     self.step.setFailed(error)
-                self.step.endTime.set(datetime.datetime.now())
+
 
 
 class ThreadStepExecutor(StepExecutor):

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -484,8 +484,8 @@ class Protocol(Step):
                 raise ex
             else:
                 time.sleep(tries)
-                self.__tryUpdateOuputSet(outputName, outputSet, state,
-                                         tries + 1)
+                self.__tryUpdateOutputSet(outputName, outputSet, state,
+                                          tries + 1)
 
     def hasExpert(self):
         """ This function checks if the protocol has


### PR DESCRIPTION
Steps window:
 - Show status.
 - Reset status, useful in some cases when a step finishes and you want to run it again (createOutputStep outputting nothing after many hours of run)

Protocol:
 _setStatusStep --> renamed to a more generic _updateSteps, receiving a lambda (callback to do the update)
 cpuTime (NEW) Integer: incremented on every finished step.
 _finalizeStep --> To finish a step anytime is "closed" (finished, aborted, failed)
 setRunning (overwritten to keep initTime when RESUMING and therefore have a "better" Wall time.
viewprotocols.py: Tooltip showing CPU time and Wall time

Closes #127 