### PR TITLE
fix_links entry point added

### DIFF
--- a/pyworkflow/constants.py
+++ b/pyworkflow/constants.py
@@ -40,7 +40,7 @@ VERSION_1 = '1.0.0'
 VERSION_1_1 = '1.1.0'
 VERSION_1_2 = '1.2.0'
 VERSION_2_0 = '2.0.0'
-VERSION_3_0 = '3.0.11'
+VERSION_3_0 = '3.0.12'
 
 # For a new release, define a new constant and assign it to LAST_VERSION
 # The existing one has to be added to OLD_VERSIONS list.

--- a/pyworkflow/project/project.py
+++ b/pyworkflow/project/project.py
@@ -1609,11 +1609,14 @@ class Project(object):
         self.settings.setReadOnly(value)
 
     def fixLinks(self, searchDir):
+        print("Fixing project links. Searching at %s" % searchDir)
         runs = self.getRuns()
 
         for prot in runs:
+            print (prot)
             broken = False
-            if isinstance(prot, ProtImportBase):
+            if isinstance(prot, ProtImportBase) or prot.getClassName() == "ProtImportMovies":
+                print("Import detected")
                 for _, attr in prot.iterOutputAttributes():
                     fn = attr.getFiles()
                     for f in attr.getFiles():

--- a/pyworkflow/project/scripts/fix_links.py
+++ b/pyworkflow/project/scripts/fix_links.py
@@ -16,24 +16,27 @@ def usage(error):
         SEARCH_DIR: provide a directory where to look for the files.
         and fix the links.    
     """ % error)
-    sys.exit(1)    
+    os._exit(1)
 
+def main():
+    if len(sys.argv) != 3:
+        usage("Incorrect number of input parameters")
 
-if len(sys.argv) != 3:
-    usage("Incorrect number of input parameters")
+    projName = sys.argv[1]
+    searchDir = os.path.abspath(sys.argv[2])
 
-projName = sys.argv[1]
-searchDir = os.path.abspath(sys.argv[2])
+    # Create a new project
+    manager = Manager()
 
-# Create a new project
-manager = Manager()
+    if not manager.hasProject(projName):
+        usage("Nonexistent project: %s" % pwutils.red(projName))
 
-if not manager.hasProject(projName):
-    usage("Nonexistent project: %s" % pwutils.red(projName))
-    
-if not os.path.exists(searchDir):
-    usage("Nonexistent SEARCH_DIR: %s" % pwutils.red(searchDir))
-    
-project = manager.loadProject(projName)
+    if not os.path.exists(searchDir):
+        usage("Nonexistent SEARCH_DIR: %s" % pwutils.red(searchDir))
 
-project.fixLinks(searchDir)
+    project = manager.loadProject(projName)
+
+    project.fixLinks(searchDir)
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,9 @@ setup(
     # For example, the following would provide a command called `sample` which
     # executes the function `main` from this package when invoked:
     entry_points={
+        'console_scripts': [
+            'fix_links = pyworkflow.project.scripts.fix_links:main',
+        ],
         'pyworkflow.plugin': 'pyworkflowtests = pyworkflowtests'
     },
 


### PR DESCRIPTION
    Usage: scipion3 run fix_links PROJECT SEARCH_DIR
        PROJECT: provide the project name to fix broken links in the imports.
        SEARCH_DIR: provide a directory where to look for the files.
        and fix the links.

This will fix broken links (in the filesystem) that are pointed by a set produced by an import movies protocol