### PR TITLE
Allow to setup a prepend command in the Environ

### DIFF
--- a/pyworkflow/utils/process.py
+++ b/pyworkflow/utils/process.py
@@ -80,8 +80,10 @@ def buildRunCommand(programname, params, numberOfMpi, hostConfig=None,
     if gpuList:
         params = params % {'GPU': ' '.join(str(g) for g in gpuList)}
 
+    prepend = '' if env is None else env.getPrepend()
+
     if numberOfMpi <= 1:
-        return '%s %s' % (programname, params)
+        return '%s %s %s' % (prepend, programname, params)
     else:
         assert hostConfig is not None, 'hostConfig needed to launch MPI processes.'
 
@@ -90,10 +92,11 @@ def buildRunCommand(programname, params, numberOfMpi, hostConfig=None,
             
         mpiFlags = '' if env is None else env.get('SCIPION_MPI_FLAGS', '') 
 
-        return hostConfig.mpiCommand.get() % {
+        mpiCmd = hostConfig.mpiCommand.get() % {
             'JOB_NODES': numberOfMpi,
             'COMMAND': "%s `which %s` %s" % (mpiFlags, programname, params),
         }
+        return '%s %s' % (prepend, mpiCmd)
 
 
 def killWithChilds(pid):

--- a/pyworkflow/utils/utils.py
+++ b/pyworkflow/utils/utils.py
@@ -166,6 +166,7 @@ class Timer(object):
     def __exit__(self, type, value, traceback):
         self.toc()
 
+
 def timeit(func):
     """ Decorator function to have a simple measurement
     of the execution time of a given function.
@@ -686,6 +687,18 @@ class Environ(dict):
             self.update({'LD_LIBRARY_PATH': libraryPath}, position=position)
         else:
             print("Some paths do not exist in: % s" % libraryPath)
+
+    def setPrepend(self, prepend):
+        """ Use this method to set a prepend string that will be added at
+        the beginning of any command that will be run in this environment.
+        This can be useful for example when 'modules' need to be loaded and
+        a simple environment variables setup is not enough.
+        """
+        setattr(self, '__prepend', prepend)
+
+    def getPrepend(self):
+        """ Return if there is any prepend value. See setPrepend function. """
+        return getattr(self, '__prepend', '')
 
 
 def existsVariablePaths(variableValue):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ configparser<=5.0.0
 matplotlib<=3.2.2
 numpy<=1.18.4
 pillow<=7.1.2
-requests<=2.23.0
+requests<=2.25.1


### PR DESCRIPTION
## Changes:
* Allow to set a 'prepend' string in the Environ: It will be used when building the command to execute. This allows to set pre-loading commands that are more complex than just defining environment variables (e.g modules system). For example, one could set in Relion: ```env.setPrepend('module load relion-3.1.1;')```. If not defined, it should not affect and maintain the current behavior. 