### PR TITLE
set sqlite temporal directory

### DIFF
--- a/pyworkflow/mapper/sqlite.py
+++ b/pyworkflow/mapper/sqlite.py
@@ -950,7 +950,7 @@ to one that has enough free space. By default this directory is /tmp
 You may achieve this goal by defining the SQLITE_TMPDIR environment variable
 and restarting scipion. Export command:
     export SQLITE_TMPDIR=. """ % str(e)
-            raise Exception(msg)
+            raise OperationalError(msg)
         
         return self.__objectsFromRows(objRows, iterate, objectFilter) 
 

--- a/pyworkflow/mapper/sqlite.py
+++ b/pyworkflow/mapper/sqlite.py
@@ -27,9 +27,7 @@ from collections import OrderedDict
 
 from pyworkflow.utils import replaceExt, joinExt
 from .sqlite_db import SqliteDb, OperationalError
-
 from .mapper import Mapper
-from .sqlite_db import SqliteDb
 
 ID = 'id'
 CREATION = 'creation'

--- a/pyworkflow/mapper/sqlite.py
+++ b/pyworkflow/mapper/sqlite.py
@@ -745,6 +745,7 @@ class SqliteFlatMapper(Mapper):
                 # #'temp_store': 'MEMORY',
                 # PRAGMA schema.cache_size = pages;
                 # #'cache_size': '5000' # versus -2000
+                "temp_store_directory": "'.'",
             }
             self.db = SqliteFlatDb(dbName, tablePrefix,
                                    pragmas=pragmas, indexes=indexes)

--- a/pyworkflow/mapper/sqlite_db.py
+++ b/pyworkflow/mapper/sqlite_db.py
@@ -30,6 +30,7 @@ This module contains some sqlite basic tools to handle Databases.
 """
 
 from sqlite3 import dbapi2 as sqlite
+from sqlite3 import OperationalError as OperationalError 
 
 from pyworkflow import SCIPION_DEBUG_SQLITE
 from pyworkflow.utils import envVarOn


### PR DESCRIPTION
I have a 4.5 million set of particles, when running the protocol "localrec extract particles2 I get the error Error: database or disk is full
It seems that the executed SQL command is: SELECT * FROM Objects WHERE 1 ORDER BY c09,c03,id ASC ;
This command creates a temporary file several times larger then the database (which is 8.8 Gb), this temporary file is too large for my /tmp directory
So I have modified the mapper such that it uses the local dir as temporary directory.

=====
SQL code that shows that the problem is indeed the temp directory
carmen@clark-cinco:~$ sqlite3 /home/carmen/ScipionUserData/projects/MartaM_Ad5_delta7/Runs/006674_ProtLocalizedRecons/coordinates.sqlite 
SQLite version 3.27.2 2019-02-25 16:06:06
Enter ".help" for usage hints.
sqlite> .output kk      -- rediret output to file 
sqlite> SELECT * FROM Objects WHERE 1 ORDER BY c09,c03,id ASC ;  -- excute command
Error: database or disk is full   -- it fails :-(
sqlite> PRAGMA temp_store_directory = '.'; -- set current dir as temporary directory using a pragma command
sqlite> SELECT * FROM Objects WHERE 1 ORDER BY c09,c03,id ASC ; -- execute command
sqlite>  -- now it does finish :-)