### PR TITLE
Ensure 3.6+ python envs have 3.2.2 version of matplotlib. 3.5 will have 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 bibtexparser<=1.2.0
 psutil<=5.7.0
 configparser<=5.0.0
-matplotlib<=3.4.1
+matplotlib==3.0.3; python_version == '3.5'
+matplotlib==3.2.2; python_version >= '3.6'
 numpy<=1.18.4
 pillow<=7.1.2
 requests<=2.25.1


### PR DESCRIPTION
This is needed for a new wizard to react to the version and reduce possibilities.

3.2.2 is still maximum supported version. At some point, we might want to upgrade it to something newer (3.4.x) but it will require some testing, so not doing it now.