### PR TITLE
Tolerate errors loading plugin icons

### DIFF
--- a/pyworkflow/constants.py
+++ b/pyworkflow/constants.py
@@ -40,7 +40,7 @@ VERSION_1 = '1.0.0'
 VERSION_1_1 = '1.1.0'
 VERSION_1_2 = '1.2.0'
 VERSION_2_0 = '2.0.0'
-VERSION_3_0 = '3.0.13'
+VERSION_3_0 = '3.0.14'
 
 # For a new release, define a new constant and assign it to LAST_VERSION
 # The existing one has to be added to OLD_VERSIONS list.

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -1652,8 +1652,15 @@ class FormWindow(Window):
         logoPath = prot.getPluginLogoPath() or getattr(package, '_logo', '')
 
         if logoPath and os.path.exists(logoPath):
+            # Tolerate error loading icons
+            try:
+                img = self.getImage(logoPath, maxheight=40)
+            except Exception as e:
+                print("Can't load plugin icon (%s): %s" % (logoPath, e))
+                img = None
+
             headerLabel = tk.Label(headerFrame, text=t, font=self.fontBig,
-                                   image=self.getImage(logoPath, maxheight=40),
+                                   image=img,
                                    compound=tk.LEFT)
         else:
             headerLabel = tk.Label(headerFrame, text=t, font=self.fontBig)


### PR DESCRIPTION
This is a quick fix to tolerate errors when loading plugins icons.

This goes as a hotfix straight to master.