### PR TITLE
Allow renaming params

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,9 @@
 -------
+v3.0.15
+-------
+ Developers:
+ - Allow renaming parameters using pyworkflow.protocol.params.DeprecatedParam
+-------
 v3.0.13
 -------
 

--- a/pyworkflow/config.py
+++ b/pyworkflow/config.py
@@ -3,6 +3,7 @@ import importlib
 import inspect
 import json
 import os
+import shutil
 import sys
 import types
 
@@ -160,6 +161,10 @@ class Config:
     # Refresh the displayed runs with a thread
     SCIPION_GUI_REFRESH_IN_THREAD = _get('SCIPION_GUI_REFRESH_IN_THREAD', 'False')
 
+    # Cancel shutil fast copy. In GPFS, shutil.copy does fail when trying a fastcopy and does not fallback on the slow copy.
+    SCIPION_CANCEL_FASTCOPY = _get('SCIPION_CANCEL_FASTCOPY', None)
+
+
     try:
         VIEWERS = ast.literal_eval(_get('VIEWERS', "{}"))
     except Exception as e:
@@ -278,3 +283,7 @@ class Config:
 
 # Add bindings folder to sys.path
 sys.path.append(Config.getBindingsFolder())
+
+# Cancel fast copy
+if Config.SCIPION_CANCEL_FASTCOPY:
+    shutil._USE_CP_SENDFILE = False

--- a/pyworkflow/constants.py
+++ b/pyworkflow/constants.py
@@ -40,7 +40,7 @@ VERSION_1 = '1.0.0'
 VERSION_1_1 = '1.1.0'
 VERSION_1_2 = '1.2.0'
 VERSION_2_0 = '2.0.0'
-VERSION_3_0 = '3.0.14'
+VERSION_3_0 = '3.0.15'
 
 # For a new release, define a new constant and assign it to LAST_VERSION
 # The existing one has to be added to OLD_VERSIONS list.

--- a/pyworkflow/protocol/params.py
+++ b/pyworkflow/protocol/params.py
@@ -542,6 +542,45 @@ class TupleParam(Param):
     def __init__(self, **args):
         Param.__init__(self, **args)
 
+class DeprecatedParam:
+    """ Deprecated param. To be used when you want to rename an existing param
+    and still be able to recover old param value. It acts like a redirector, passing the
+    value received when its value is set to the new renamed parameter
+
+    usage: In defineParams method, before the renamed param definition line add the following:
+
+    self.oldName = DeprecatedParam("newName", self)
+    form.addParam('newName', ...)
+
+    """
+    def __init__(self, newParamName, prot):
+        """
+
+        :param newParamName: Name of the renamed param
+        :param prot: Protocol hosting this and the renamed param
+
+        """
+        self._newParamName = newParamName
+        self.prot = prot
+        # Need to fake being a Object at loading time
+        self._objId = None
+        self._objIsPointer = False
+
+    def set(self, value):
+        if hasattr(self.prot, self._newParamName):
+            newParam = self._getNewParam()
+            newParam.set(value)
+            if newParam.isPointer():
+                self._extended = newParam._extended
+
+    def isPointer(self):
+        return self._getNewParam().isPointer()
+
+    def getObjValue(self):
+        return None
+
+    def _getNewParam(self):
+        return getattr(self.prot, self._newParamName)
 
 # -----------------------------------------------------------------------------
 #         Validators


### PR DESCRIPTION
this allow protocol parameters to be renamed...probably even change its data type (renamed is forced in this case)
Also add an optional config variable to cancel fast copy functionality from shutil that in GPFS filesystem is reported to be failing. 