### PR TITLE
Form in wizards contains the paramName of the param clicked

### DIFF
--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -1096,6 +1096,7 @@ class ParamWidget:
     def _showWizard(self, e=None):
         wizClass = self.window.wizards[self.wizParamName]
         wizard = wizClass()
+        self.window.wizParamName = self.wizParamName
         wizard.show(self.window)
 
     def _findParamWizard(self):


### PR DESCRIPTION
Form in wizards contains the paramName of the param clicked.
This way wizards' show can know which parameter has been clicked