### PR TITLE
plugin.py: Splited getPluginTemplateDir

### DIFF
--- a/pyworkflow/plugin.py
+++ b/pyworkflow/plugin.py
@@ -603,8 +603,13 @@ class Plugin:
             return ["validateInstallation fails: %s" % e]
 
     @classmethod
+    def getPluginDir(cls):
+        return os.path.join(pw.getModuleFolder(cls.getName()))
+
+    @classmethod
     def getPluginTemplateDir(cls):
-        return os.path.join(pw.getModuleFolder(cls.getName()), 'templates')
+        return os.path.join(cls.getPluginDir(), 'templates')
+
 
     @classmethod
     def getTemplates(cls):


### PR DESCRIPTION
 to get access at the path of a plugin