### PR TITLE
Fix bug in pw_schedule_run

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+V3.0.23
+-------
+- Fixing a bug for static protocols: when a protocol had another protocol as input, it failed to wait until it had finish.
+
+
 V3.0.22
 -------
 - Fixing a persistent error related with the logic of the EXECUTE/SCHEDULE button

--- a/pyworkflow/apps/pw_schedule_run.py
+++ b/pyworkflow/apps/pw_schedule_run.py
@@ -236,8 +236,13 @@ class RunScheduler:
                 inSet = attr.get()
                 if isinstance(inSet, Set) and inSet.isStreamOpen():
                     inputMissing = True
-                    self._log("Waiting for closing %s... (%s does not work in "
-                              "streaming)" % (inSet, self.protocol))
+                    self._log("Waiting for closing %s... (does not work in "
+                              "streaming)" % inSet)
+                    break
+                elif isinstance(inSet, Protocol) and not inSet.isFinished():  # Then is a pointer to a protocol
+                    inputMissing = True
+                    self._log("Waiting for protocol %s to finish... (does not work in "
+                              "streaming)" % inSet)
                     break
 
         if not inputMissing:


### PR DESCRIPTION
Fixing a bug for static protocols. When a protocol had another protocol as input, it failed to wait until it had finish.