### PR TITLE
Fix test output

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,12 +5,14 @@ V3.0.23
  - Filebrowser has 2 new shortcuts: "recent" and "Protocol folder"
  - Text widget: "File does not exist message" removed.
  - Rescue colors in terminal
-
+ - Rescue output in tests.
 
 Developers:
  - Some modules switched to use logger instead of print: viewprotocols.py, browser.py and launch.py,
    pw_schedule_run.py, viewprojects.py, canvas.py, project.py, protocol.py.
  - LoggerConfigurator adapted to received logfile, flag for console handler and line format.
+ - pw_run_tests.py uses logging now.
+ - tests mode with --log now works. All goes to the same file and is not html.
 
 V3.0.22
 -------

--- a/pyworkflow/apps/pw_run_tests.py
+++ b/pyworkflow/apps/pw_run_tests.py
@@ -30,7 +30,7 @@ Run or show the selected tests. Tests can be selected by giving
 the "case", or by giving the paths and file pattern to use for
 searching them.
 """
-from os.path import basename
+from pyworkflow.utils import LoggingConfigurator
 import argparse
 from collections import OrderedDict
 
@@ -46,7 +46,6 @@ TEST = 2
 
 class Tester:
     def main(self, args=None):
-        print("Running tests....")
 
         # Trigger plugin's variable definition
         Config.getDomain().getPlugins()
@@ -76,6 +75,18 @@ class Tester:
         if not args.run and not args.show and not args.tests:
             sys.exit(parser.format_help())
 
+        # Logging stuff first
+        self.log = args.log
+
+        if self.log:
+            LoggingConfigurator.setupLogging(logFile=self.log, lineFormat="%(message)s")
+        else:
+            logging.basicConfig(level=Config.SCIPION_LOG_LEVEL, format="%(message)s")
+
+        self.logger = logging.getLogger(__name__)
+
+        self.logger.info("Running tests....")
+
         testsDict = OrderedDict()
         testLoader = unittest.defaultTestLoader
 
@@ -87,9 +98,7 @@ class Tester:
                 try:
                     testsDict['tests'].addTests(testLoader.loadTestsFromName(t))
                 except Exception as e:
-                    print('Cannot load test %s -- skipping' % t)
-                    import traceback
-                    traceback.print_exc()
+                    self.logger.error('Cannot load test %s -- skipping' % t, exc_info=True)
         else:
             # In this other case, we will load the test available
             # from pyworkflow and the other plugins
@@ -107,14 +116,13 @@ class Tester:
         self.grep = [g.lower() for g in args.grep] if args.grep else []
         self.skip = args.skip
         self.mode = args.mode
-        self.log = args.log
 
         if args.tests:
             self.runSingleTest(testsDict['tests'])
 
         elif args.run:
             for moduleName, tests in testsDict.items():
-                print(pwutils.cyan(">>>> %s" % moduleName))
+                self.logger.info(pwutils.cyanStr(">>>> %s" % moduleName))
                 self.runTests(moduleName, tests)
 
         elif args.grep:
@@ -125,7 +133,7 @@ class Tester:
         else:
             for moduleName, tests in testsDict.items():
                 if self._match(moduleName):
-                    print(pwutils.cyan(">>>> %s" % moduleName))
+                    print(pwutils.cyanStr(">>>> %s" % moduleName))
                     self.printTests(moduleName, tests)
 
     def _match(self, itemName):
@@ -139,7 +147,7 @@ class Tester:
 
     def __iterTests(self, test):
         """ Recursively iterate over a testsuite. """
-        print("__iterTests: %s, is-suite: %s" % (str(test.__class__),
+        self.logger.debug("__iterTests: %s, is-suite: %s" % (str(test.__class__),
                                                  isinstance(test, unittest.TestSuite)))
 
         if isinstance(test, unittest.TestSuite):
@@ -181,8 +189,8 @@ class Tester:
                 if testModuleName.startswith(errorStr):
                     newName = t.id().replace(errorStr, '')
                     if self._match(newName):
-                        print(pwutils.red('Error loading the test. Please, run the test for more information:'),
-                              newName)
+                        self.logger.error(
+                            pwutils.redStr('Error loading the test. Please, run the test for more information: ' + newName))
                     continue
 
                 if testModuleName != lastModule:
@@ -200,11 +208,12 @@ class Tester:
                                     % (testModuleName, className, testName))
         else:
             if not self.grep:
-                print(pwutils.green(' The plugin does not have any test'))
+                self.logger.warning(pwutils.greenStr(' The plugin does not have any test'))
 
     def _printNewItem(self, itemType, itemName):
         if self._match(itemName):
             spaces = (itemType * 2) * ' '
+            # Do not use intentionally the logger. This is not a logging output but a GUI output
             print("%s %s %s" % (spaces, self.getTestsCommand(), itemName))
 
     def getTestsCommand(self):
@@ -212,27 +221,6 @@ class Tester:
 
     def printTests(self, moduleName, tests):
         self._visitTests(moduleName, tests, self._printNewItem)
-
-    def _logTest(self, cmd, runTime, result, logFile):
-        with open(self.testLog, "r+") as f:
-            lines = f.readlines()
-            f.seek(0)
-            for l in lines:
-                if '<!-- LAST_ROW -->' in l:
-                    rowStr = "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>"
-                    if result:  # != 0 means failed in os.system
-                        resultStr = '<font color="red">[FAILED]</font>'
-                    else:
-                        resultStr = '<font color="green">[SUCCEED]</font>'
-                    logStr = '<a href="file://%s">%s</a>' % (logFile, basename(logFile))
-
-                    f.write(rowStr % (self.testCount, cmd, runTime, resultStr, logStr))
-                    f.write('\n')
-                if self.headerPrefix in l:
-                    f.write(self.headerPrefix + self.testTimer.getToc() + '</h3>\n')
-                else:
-                    f.write(l)
-            f.close()
 
     def _runNewItem(self, itemType, itemName):
         if self._match(itemName):
@@ -244,58 +232,22 @@ class Tester:
                    (itemType == TEST and self.mode == 'all'))
             if run:
                 if self.log:
-                    logFile = join(self.testsDir, '%s.txt' % itemName)
-                    cmdFull = cmd + " > %s 2>&1" % logFile
+                    # logFile = join(self.testsDir, '%s.txt' % itemName)
+                    cmdFull = cmd + " >> %s 2>&1" % self.log
                 else:
                     logFile = ''
                     cmdFull = cmd
 
-                print(pwutils.green(cmdFull))
+                self.logger.info(pwutils.greenStr(cmdFull))
                 t = pwutils.Timer()
                 t.tic()
                 self.testCount += 1
-                result = os.system(cmdFull)
-                if self.log:
-                    self._logTest(cmd, t.getToc(), result, logFile)
+                os.system(cmdFull)
 
     def runTests(self, moduleName, tests):
+
         self.testCount = 0
-
-        if self.log:
-            self.testsDir = join(pw.Config.SCIPION_USER_DATA, 'Tests', self.log)
-            pwutils.cleanPath(self.testsDir)
-            pwutils.makePath(self.testsDir)
-            self.testLog = join(self.testsDir, 'tests.html')
-            self.testTimer = pwutils.Timer()
-            self.testTimer.tic()
-            self.headerPrefix = '<h3>Test results (%s) Duration: ' % pwutils.prettyTime()
-            f = open(self.testLog, 'w')
-            f.write("""<!DOCTYPE html>
-    <html>
-    <body>
-    """)
-            f.write(self.headerPrefix + '</h3>')
-            f.write("""    
-     <table style="width:100%" border="1">
-      <tr>
-        <th>#</th>
-        <th>Command</th>
-        <th>Time</th>
-        <th>Result</th>
-        <th>Log file</th>
-      </tr>
-    <!-- LAST_ROW -->
-    </table> 
-    
-    </body>
-    </html>""")
-
-            f.close()
         self._visitTests(moduleName, tests, self._runNewItem)
-
-        if self.log:
-            print("\n\nOpen results in your browser: \nfile:///%s"
-                  % self.testLog)
 
     def runSingleTest(self, tests):
         result = pwtests.GTestResult()

--- a/pyworkflow/tests/tests.py
+++ b/pyworkflow/tests/tests.py
@@ -1,3 +1,6 @@
+import logging
+logger = logging.getLogger(__name__)
+
 import sys
 import os
 import time
@@ -63,7 +66,7 @@ class DataSet:
         if not pwutils.envVarOn('SCIPION_TEST_NOSYNC'):
             command = ("%s %s --download %s %s"
                        % (pw.PYTHON, pw.getSyncDataScript(), folder, url))
-            print(">>>> %s" % command)
+            logger.info(">>>> %s" % command)
             os.system(command)
 
         return cls._datasetDict[name]
@@ -133,11 +136,11 @@ class BaseTest(unittest.TestCase):
         # For each log file to print
         for key in logs:
 
-            print(pwutils.cyanStr("\n*************** last %s lines of %s *********************\n" % (lastLines, key)))
+            logger.info(pwutils.cyanStr("\n*************** last %s lines of %s *********************\n" % (lastLines, key)))
             logLines = prot.getLogsLastLines(lastLines, logFile=logs[key])
             for i in range(0, len(logLines)):
-                print(logLines[i])
-            print(pwutils.cyanStr("\n*************** end of %s *********************\n" % key))
+                logger.info(logLines[i])
+            logger.info(pwutils.cyanStr("\n*************** end of %s *********************\n" % key))
 
             sys.stdout.flush()
 
@@ -169,7 +172,7 @@ class BaseTest(unittest.TestCase):
             time.sleep(sleepTime)
             prot2 = _loadProt()
             if counter > numberOfSleeps:
-                print("Timeout (%s) reached waiting for %s at %s" % (timeOut, outputAttributeName, prot))
+                logger.warning("Timeout (%s) reached waiting for %s at %s" % (timeOut, outputAttributeName, prot))
                 break
             counter += 1
 
@@ -200,7 +203,7 @@ class BaseTest(unittest.TestCase):
         for item1, item2 in zip(set1, set2):
             areEqual = item1.equalAttributes(item2)
             if not areEqual:
-                print("item 1 and item2 are different: ")
+                logger.info("item 1 and item2 are different: ")
                 item1.printAll()
                 item2.printAll()
             test.assertTrue(areEqual)
@@ -245,7 +248,7 @@ def setupTestProject(cls, writeLocalConfig=False):
 
     if writeLocalConfig:
         hostsConfig = '/tmp/hosts.conf'
-        print("Writing local config: %s" % hostsConfig)
+        logger.info("Writing local config: %s" % hostsConfig)
         import pyworkflow.protocol as pwprot
         pwprot.HostConfig.writeBasic(hostsConfig)
 
@@ -279,14 +282,14 @@ class GTestResult(unittest.TestResult):
 
     def doReport(self):
         secs = time.time() - self.startTimeAll
-        sys.stderr.write("\n%s run %d tests (%0.3f secs)\n" %
+        logger.info("\n%s run %d tests (%0.3f secs)\n" %
                          (pwutils.greenStr("[==========]"),
                           self.numberTests, secs))
         if self.testFailed:
-            sys.stderr.write("%s %d tests\n"
+            logger.info("%s %d tests\n"
                              % (pwutils.redStr("[  FAILED  ]"),
                                 self.testFailed))
-        sys.stdout.write("%s %d tests\n"
+        logger.info("%s %d tests\n"
                          % (pwutils.greenStr("[  PASSED  ]"),
                             self.numberTests - self.testFailed))
 
@@ -310,14 +313,14 @@ class GTestResult(unittest.TestResult):
 
     def addSuccess(self, test):
         secs = self.toc()
-        sys.stderr.write("%s %s (%0.3f secs)\n" %
+        logger.info("%s %s (%0.3f secs)\n" %
                          (pwutils.greenStr('[ RUN   OK ]'),
                           self.getTestName(test), secs))
 
     def reportError(self, test, err):
-        sys.stderr.write("%s %s\n" % (pwutils.redStr('[   FAILED ]'),
+        logger.info("%s %s\n" % (pwutils.redStr('[   FAILED ]'),
                                       self.getTestName(test)))
-        sys.stderr.write("\n%s"
+        logger.info("\n%s"
                          % pwutils.redStr("".join(format_exception(*err))))
         self.testFailed += 1
 

--- a/pyworkflow/utils/log.py
+++ b/pyworkflow/utils/log.py
@@ -67,9 +67,9 @@ class LoggingConfigurator:
     customLoggingActive = False  # Holds if a custom logging configuration has taken place.
 
     @classmethod
-    def setupLogging(cls):
+    def setupLogging(cls, logFile=None, console=True, lineFormat=None):
         if not cls.loadCustomLoggingConfig():
-            cls.setupDefaultLogging()
+            cls.setupDefaultLogging(logFile=logFile, console=console, lineFormat=lineFormat)
 
     @classmethod
     def loadCustomLoggingConfig(cls):
@@ -143,7 +143,7 @@ class LoggingConfigurator:
             config['loggers']['']['handlers'].append(CONSOLE_HANDLER)
 
         # Create the log folder
-        os.makedirs(os.path.dirname(logFile), exist_ok=True)
+        os.makedirs(os.path.dirname(os.path.abspath(logFile)), exist_ok=True)
 
         logging.config.dictConfig(config)
 


### PR DESCRIPTION
This should bring back the output in the tests. 

Progresively, testing code, should replace "prints" with "logger.info" to benefit from the logging functionality.