### PR TITLE
substitute GPU ids in programname

### DIFF
--- a/pyworkflow/utils/process.py
+++ b/pyworkflow/utils/process.py
@@ -80,6 +80,9 @@ def buildRunCommand(programname, params, numberOfMpi, hostConfig=None,
 
     if gpuList:
         params = params % {'GPU': ' '.join(str(g) for g in gpuList)}
+        if "CUDA_VISIBLE_DEVICES" in programname:
+            sep = "," if len(gpuList) > 1 else ""
+            programname = programname % {'GPU': sep.join(str(g) for g in gpuList)}
 
     prepend = '' if env is None else env.getPrepend()
 


### PR DESCRIPTION
Fixes #364 . @pconesa, I think CUDA_VISIBLE_DEVICES is quite common var name to happen inside programname. The syntax is always "CUDA_VISIBLE_DEVICES=0,1" with a comma
But maybe you can offer a better alternative.

I need to test this. At the moment substitution works but I still get all GPU ids in each runJob command - i.e. they are not split among threads..