### PR TITLE
clear pointers when saving the form in case their condition is false …

### DIFF
--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -220,6 +220,11 @@ class MultiPointerVar:
             self.provider.removeObject(v)
         self._updateObjectsList()
 
+    def clear(self):
+        self.provider.clear()
+        self._updateObjectsList()
+
+
     def getSelectedObjects(self):
         return self.tree.getSelectedObjects()
 
@@ -302,6 +307,9 @@ class MultiPointerTreeProvider(TreeProvider):
     def getObjectInfo(self, obj):
         label, info = getPointerLabelAndInfo(obj, self._mapper)
         return {'key': obj._strId, 'text': label, 'values': ('  ' + info,)}
+
+    def clear(self):
+        self._objectDict.clear()
 
 
 class ComboVar:
@@ -1370,16 +1378,20 @@ class ParamWidget:
                          selectmode=self._selectmode, selectOnDoubleClick=True)
 
         if dlg.values:
-            if isinstance(self.param, pwprot.MultiPointerParam):
+            if self.isMultiPointer():
                 self.set(dlg.values)
             elif isinstance(self.param, pwprot.PointerParam):
                 self.set(dlg.values[0])
             else:
                 raise Exception('Invalid param class: %s' % type(self.param))
 
+    def isMultiPointer(self):
+        """ True if dealing with MultiPointer params """
+        return isinstance(self.param, pwprot.MultiPointerParam)
+
     def _browseScalar(self, e=None):
         """Select a scalar from outputs
-        This function is suppose to be used only for Scalar Params
+        This function is supposed to be used only for Scalar Params
         It's a copy of browseObject...so there could be a refactor here."""
         value = self.get()
         selected = []
@@ -1414,6 +1426,16 @@ class ParamWidget:
     def _removeObject(self, e=None):
         """ Remove an object from a MultiPointer param. """
         self.var.remove()
+
+    def clear(self):
+
+        # If dealing with Multipointers ...
+        if self.isMultiPointer():
+            # .. use var clear to remove all eletents since
+            # _removeObject() will remove only the selected ones
+            self.var.clear()
+        else:
+            self._removeObject()
 
     def _browseRelation(self, e=None):
         """Select a relation from DB
@@ -2277,6 +2299,10 @@ class FormWindow(Window):
             # Set the protocol label
             self.updateProtocolLabel()
 
+            # Clear parameters that are pointers and do not match the condition
+            # to avoid ghost inputs
+            self._checkAllChanges(toggleWidgetVisibility=False)
+
             message = self.callback(self.protocol, onlySave, doSchedule)
             if not self.visualizeMode:
                 if len(message):
@@ -2410,7 +2436,7 @@ class FormWindow(Window):
             c += 2
             self.widgetDict[paramName] = widget
 
-    def _checkCondition(self, paramName):
+    def _checkCondition(self, paramName, toggleWidgetVisibility=True):
         """Check if the condition of a param is satisfied
         hide or show it depending on the result"""
         widget = self.widgetDict.get(paramName, None)
@@ -2420,8 +2446,14 @@ class FormWindow(Window):
                 param = widget.param
             else:
                 param = self.protocol.getParam(paramName)
-            cond = self.protocol.evalParamCondition(paramName) and self.protocol.evalParamExpertLevel(param)
-            widget.display(cond)
+            show = self.protocol.evalParamCondition(paramName) and self.protocol.evalParamExpertLevel(param)
+
+            if toggleWidgetVisibility:
+                widget.display(show)
+            else:
+                # If condition is false and param is a pointer, or Multipointer ...
+                if (not show) and isinstance(param, pwprot.PointerParam):
+                    widget.clear()
 
     def _checkChanges(self, paramName):
         """Check the conditions of all params affected
@@ -2434,9 +2466,9 @@ class FormWindow(Window):
 
         self.adjustSections()
 
-    def _checkAllChanges(self):
+    def _checkAllChanges(self, toggleWidgetVisibility=True):
         for paramName in self.widgetDict:
-            self._checkCondition(paramName)
+            self._checkCondition(paramName, toggleWidgetVisibility=toggleWidgetVisibility)
 
     def _onExpertLevelChanged(self, *args):
         self._checkAllChanges()


### PR DESCRIPTION
Clear pointers when saving the form in case their condition is false. 
If the pointers are not cleaned then ghost relationship may be created.

For example, in protocol chimerax-import alphafold users may choose between searching in the alphafold database or running a new inference.  Let us assume that I copy a chimerax-alphafol protocol in which a search in the database was made (this option requires a sequence as input).  In the copy I select the option that runs a new inference (that uses as input a set of sequences). If I save the protocol  the new protocol, it is linked to the sequence used by the option "search in the database" even if this sequence is not used at all.