### PR TITLE
fix queue-system's job status check when QUEUE_FOR_JOBS function is e…

### DIFF
--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -320,7 +320,7 @@ class QueueStepExecutor(ThreadStepExecutor):
         command = hostConfig.getCheckCommand() % {"JOB_ID": jobid}
         p = Popen(command, shell=True, stdout=PIPE, preexec_fn=os.setsid)
 
-        out = p.communicate()[0]
+        out = p.communicate()[0].decode(errors='backslashreplace')
 
         jobDoneRegex = hostConfig.getJobDoneRegex()
 


### PR DESCRIPTION
…nabled

If user was using the queue system and Scipion was configured to use the QUEUE_FOR_JOBS option, the CHECK_COMMAND variable that specifies a command to check the job status didn't work. The content of the command response in the form `bytes` was checking against an empty string in the form `str`.

[https://scipion-em.github.io/docs/release-3.0.0/docs/scipion-modes/host-configuration.html#queue-system](https://scipion-em.github.io/docs/release-3.0.0/docs/scipion-modes/host-configuration.html#queue-system)