### PR TITLE
- Do not allow empty Config variables unless is the default value

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,9 +5,12 @@ users:
   - Labels and box positions are saved after Labels being edited.
   - scipion3 project list (or without list) should list existing projects.
   - Windows are grouped by project under the project name.
+  - Do not allow empty Config variables unless is the default value
+  - SCIPION_MAIN_COLOR: If not valid, fallsback to Firebrick
+  - Project names: Only accepts digits, "letters", - or _. Rest are turned into -
 developers:
   - Tolerate loading of extra set properties but WARN the developer.
-
+  - Show info id debug mode (print) when an infinite loop happens in the protocols graph
 V3.1.0
 ------
 users:

--- a/pyworkflow/config.py
+++ b/pyworkflow/config.py
@@ -413,7 +413,7 @@ class Config:
             from pyworkflow.utils import lighter, rgb_to_hex
             try:
                 rgb_main = matplotlib.colors.to_rgb(cls.SCIPION_MAIN_COLOR)
-            except Exception as e:
+            except Exception:
                 logger.error("Cannot convert SCIPION_MAIN_COLOR (%s) string to a color to compute the lighter color."
                              " Falling back to %s" % (Config.SCIPION_MAIN_COLOR, Color.MAIN_COLOR))
                 cls.SCIPION_MAIN_COLOR = Color.MAIN_COLOR

--- a/pyworkflow/config.py
+++ b/pyworkflow/config.py
@@ -77,6 +77,11 @@ class Config:
     @staticmethod
     def __get(key, default):
         value = os.environ.get(key, default)
+
+        # If empty use default value
+        if value == "" != default:
+            logger.warning("%s variable is empty, falling back to default value (%s)" % (key, default))
+            value = default
         # Expand user and variables if string value
         if isinstance(value, str):
             value = os.path.expandvars(os.path.expanduser(value))
@@ -403,8 +408,14 @@ class Config:
         if cls.__activeColor is None:
             import matplotlib.colors
             from pyworkflow.utils import lighter, rgb_to_hex
+            try:
+                rgb_main = matplotlib.colors.to_rgb(cls.SCIPION_MAIN_COLOR)
+            except Exception as e:
+                logger.error("Cannot convert SCIPION_MAIN_COLOR (%s) string to a color to compute the lighter color."
+                             " Falling back to %s" % (Config.SCIPION_MAIN_COLOR, Color.MAIN_COLOR))
+                cls.SCIPION_MAIN_COLOR = Color.MAIN_COLOR
+                rgb_main = matplotlib.colors.to_rgb(cls.SCIPION_MAIN_COLOR)
 
-            rgb_main = matplotlib.colors.to_rgb(cls.SCIPION_MAIN_COLOR)
             rgb_main = (rgb_main[0] * 255, rgb_main[1] * 255, rgb_main[2] * 255)
             rgb_active = lighter(rgb_main, 0.3)
             cls.__activeColor = rgb_to_hex(rgb_active)

--- a/pyworkflow/gui/graph_layout.py
+++ b/pyworkflow/gui/graph_layout.py
@@ -133,7 +133,8 @@ class LevelTreeLayout(GraphLayout):
     
             if self.__isNodeExpanded(node):
                 for child in node.getChilds():
-                    logger.debug("%s: Setting layout for child %s" % ("-" * level, child))
+                    if Config.debugOn():
+                        print("%s: Setting layout for child %s" % ("-" * level, child), flush=True)
                     self._setLayoutLevel(child, level+1, node)
 
     def __isNodeExpanded(self, node):

--- a/pyworkflow/project/project.py
+++ b/pyworkflow/project/project.py
@@ -1742,9 +1742,10 @@ class Project(object):
     @staticmethod
     def cleanProjectName(projectName):
         """ Cleans a project name to avoid common errors
-        Use it whenever you want to get the final project name pyworkflow will endup.
+        Use it whenever you want to get the final project name pyworkflow will end up.
         Spaces will be replaced by _ """
-        return projectName.replace(" ", "_")
+
+        return re.sub("[^\w\d\-\_]", "-", projectName)
 
 
 class MissingProjectDbException(Exception):


### PR DESCRIPTION
- SCIPION_MAIN_COLOR: If not valid, fallsback to Firebrick
- Project names: Only accepts digits, "letters", - or _. Rest are turned into -
- Show info id debug mode (print) when an infinite loop happens in the protocols graph