### PR TITLE
remove hostname from the form

### DIFF
--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -1936,7 +1936,7 @@ class FormWindow(Window):
             btnHelp.grid(row=0, column=2, padx=(5, 0), pady=2, sticky='e')
         modeFrame.columnconfigure(0, weight=1)
         modeFrame.grid(row=r, column=1, sticky='ew', columnspan=2)
-
+        r=2
         self._createParallel(runFrame, r)
 
         # ---- QUEUE ----

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -1624,14 +1624,13 @@ class FormWindow(Window):
     
     Layout:
         There are 4 main blocks that goes each one in a different row1.
-        1. Header: will contains the logo, title and some link buttons.
+        1. Header: will contain the logo, title and some link buttons.
         2. Common: common execution parameters of each run.
         3. Params: the expert level and tabs with the Protocol parameters.
         4. Buttons: buttons at bottom for close, save and execute.
     """
 
-    def __init__(self, title, protocol, callback, master=None,
-                 hostList=['localhost'], **kwargs):
+    def __init__(self, title, protocol, callback, master=None, **kwargs):
         """ Constructor of the Form window. 
         Params:
          title: title string of the windows.
@@ -1647,7 +1646,6 @@ class FormWindow(Window):
         self.visualizeDict = kwargs.get('visualizeDict', {})
         self.disableRunMode = kwargs.get('disableRunMode', False)
         self.bindings = []
-        self.hostList = hostList
         self.protocol = protocol
         # This control when to close or not after execute
         self.visualizeMode = kwargs.get('visualizeMode', False)
@@ -1939,20 +1937,6 @@ class FormWindow(Window):
         modeFrame.columnconfigure(0, weight=1)
         modeFrame.grid(row=r, column=1, sticky='ew', columnspan=2)
 
-        # ---- Host---- 
-        self._createHeaderLabel(runFrame, pwutils.Message.LABEL_HOST, row=r, column=c,
-                                sticky='e')
-        # Keep track of hostname selection
-        self.hostVar = tk.StringVar()
-        protHost = self.protocol.getHostName()
-        hostName = protHost if protHost in self.hostList else self.hostList[0]
-        self.hostVar.trace('w', self._setHostName)
-        self.hostCombo = ttk.Combobox(runFrame, textvariable=self.hostVar,
-                                      state='readonly', width=10, font=self.font)
-        self.hostCombo['values'] = self.hostList
-        self.hostVar.set(hostName)
-        self.hostCombo.grid(row=r, column=c + 1, pady=0, sticky='we')
-        r = 2
         self._createParallel(runFrame, r)
 
         # ---- QUEUE ----
@@ -1977,7 +1961,7 @@ class FormWindow(Window):
 
         btnHelp.grid(row=r, column=c + 2, padx=(5, 0), pady=5, sticky='w')
 
-        r = 3  # ---- Wait for other protocols (SCHEDULE) ----
+        r = 2  # ---- Wait for other protocols (SCHEDULE) ----
         self._createHeaderLabel(runFrame, pwutils.Message.LABEL_WAIT_FOR, row=r, sticky='e',
                                 column=c, padx=(15, 5), pady=0)
         self.waitForVar = tk.StringVar()

--- a/pyworkflow/gui/project/viewdata.py
+++ b/pyworkflow/gui/project/viewdata.py
@@ -434,8 +434,7 @@ class ProjectDataView(tk.Frame):
         """Open the Protocol GUI Form given a Protocol instance"""
         title = pwutils.Message.TITLE_NAME_RUN + prot.getClassName()
         w = gui.form.FormWindow(title, prot, self._executeSaveProtocol,
-                                self.windows,
-                                hostList=self.project.getHostNames())
+                                self.windows)
         w.adjustSize()
         w.show(center=True)
 

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -1391,7 +1391,6 @@ class ProtocolsView(tk.Frame):
 
         w = FormWindow(Message.TITLE_NAME_RUN + prot.getClassName(),
                        prot, self._executeSaveProtocol, self.window,
-                       hostList=self.project.getHostNames(),
                        updateProtocolCallback=self._updateProtocol,
                        disableRunMode=disableRunMode)
         w.adjustSize()

--- a/pyworkflow/protocol/hosts.py
+++ b/pyworkflow/protocol/hosts.py
@@ -36,7 +36,7 @@ from configparser import RawConfigParser
 from collections import OrderedDict
 
 import pyworkflow as pw
-from pyworkflow.object import Object, String, Integer, Boolean
+from pyworkflow.object import Object, String, Integer
 
 
 class HostConfig(Object):
@@ -311,44 +311,3 @@ class QueueSystemConfig(Object):
                 if objId == queueConfig.getObjId():
                     return queueConfig
         return None
-
-
-# TODO: maybe deprecated
-class QueueConfig(Object):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.name = String('default')
-        self.maxCores = Integer()
-        self.allowMPI = Boolean()
-        self.allowThreads = Boolean()
-        self.maxHours = Integer()
-
-    def getName(self):
-        return self.name.get()
-
-    def getMaxCores(self):
-        return self.maxCores.get()
-
-    def getAllowMPI(self):
-        return self.allowMPI.get()
-
-    def getAllowThreads(self):
-        return self.allowThreads.get()
-
-    def getMaxHours(self):
-        return self.maxHours.get()
-
-    def setName(self, name):
-        self.name.set(name)
-
-    def setMaxCores(self, maxCores):
-        self.maxCores.set(maxCores)
-
-    def setAllowMPI(self, allowMPI):
-        self.allowMPI.set(allowMPI)
-
-    def setAllowThreads(self, allowThreads):
-        self.allowThreads.set(allowThreads)
-
-    def setMaxHours(self, maxHours):
-        self.maxHours.set(maxHours)


### PR DESCRIPTION
We do not support remote host executions, so this param wastes form space.