### PR TITLE
Update protocols outputs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,8 +22,9 @@ developers:
   - Object.getClassName is now a class method
   - Validating the Close method in the Dialog class. Now we can to reimplement de validateClose method.
   - Better case-specific implementation of pID and jobID. Three scenarios: normal execution, sending the entire protocol to the queue, or sending individual steps.
-  - Object.clone an copy optionaly clones the enable flag
-  - Set.getItem: returns the first item with a value in the fiels passed. Useful for querying by TsId in tomo.
+  - Object.clone a copy optionally clones the enable flag
+  - Set.getItem: returns the first item with a value in the fields passed. Useful for querying by TsId in tomo.
+  - Correctly update the protocols in streaming workflows when the input pointer points to a protocol, the protocol points to a set (i.e., classes), and this set points to another set (i.e., particles).
 
 V3.4.0
 ------

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -761,7 +761,6 @@ class Protocol(Step):
                                                    f"in streaming scenarios. Developers should avoid them.")
 
             protocolIds.append(protocol.getObjId())
-            logger.debug('Protocols Ids: %s' % protocolIds)
 
         return protocolIds
 

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -713,9 +713,12 @@ class Protocol(Step):
         protocolIds = []
         protocol = None
         for key, attrInput in self.iterInputAttributes():
+            outputs = []
             output = attrInput.get()
             if isinstance(output, Protocol):  # case A
                 protocol = output
+                for _, protOutput in protocol.iterOutputAttributes():
+                    outputs.append(protOutput)  # for case A store all the protocols outputs
             else:
                 if attrInput.hasExtended():  # case B
                     protocol = attrInput.getObjValue()
@@ -736,8 +739,13 @@ class Protocol(Step):
                               "scheduling protocols. Value: %s" % (key, self, attrInput))
                         continue
 
-                # If there is output
                 if output is not None:
+                    outputs.append(output)
+
+            # If there is output
+            if outputs:
+                # Iter over all the outputs
+                for output in outputs:
                     # For each output attribute: Looking for pointers like SetOfCoordinates.micrographs
                     for k, attr in output.getAttributes():
                         # If it's a pointer
@@ -751,7 +759,9 @@ class Protocol(Step):
                                     logger.warning(f"We have found that {output}.{key} points to {attr} "
                                                    f"and is a direct pointer. Direct pointers are less reliable "
                                                    f"in streaming scenarios. Developers should avoid them.")
+
             protocolIds.append(protocol.getObjId())
+            logger.debug('Protocols Ids: %s' % protocolIds)
 
         return protocolIds
 


### PR DESCRIPTION
Correctly update the protocols in streaming workflows when the input pointer points to a protocol, the protocol points to a set (i.e., classes), and this set points to another set (i.e., particles).

Relion Ranker is an example of this behavior. 