### PR TITLE
Improve the DDBB lock in the method "_store". If Protocol._lock is lo…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+V3.6.1
+developers:
+  - Improve the DDBB lock in the method "_store". If Protocol._lock is locked, a nullcontext is used instead of another
+    Protocol._lock context, which causes a permanent lock.
 V3.6.0
 users:
   - Window to see/edit config variables. Launched from Project menu in project window.

--- a/pyworkflow/constants.py
+++ b/pyworkflow/constants.py
@@ -42,7 +42,7 @@ VERSION_1 = '1.0.0'
 VERSION_1_1 = '1.1.0'
 VERSION_1_2 = '1.2.0'
 VERSION_2_0 = '2.0.0'
-VERSION_3_0 = '3.6.0'
+VERSION_3_0 = '3.6.1'
 
 # For a new release, define a new constant and assign it to LAST_VERSION
 # The existing one has to be added to OLD_VERSIONS list.

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -25,6 +25,7 @@
 This modules contains classes required for the workflow
 execution and tracking like: Step and Protocol
 """
+import contextlib
 import sys, os
 import json
 import threading
@@ -956,7 +957,9 @@ class Protocol(Step):
         If not objects are passed, the whole protocol is stored.
         """
         if self.mapper is not None:
-            with self._lock:
+
+            lock = contextlib.nullcontext() if self._lock.locked() else self._lock
+            with lock:
                 if len(objs) == 0:
                     self.mapper.store(self)
                 else:


### PR DESCRIPTION
…cked, a nullcontext is used instead of another

    Protocol._lock context, which causes a permanent lock.
    Bump version.