### PR TITLE
Avoiding a double process when launching a workflow using the protocol form

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,12 +3,14 @@ V3.6.1
 user:
   - Streaming protocols based on new streaming (generation steps) are resumable
   - pyworkflowtest fixed
+  - Avoiding a double process when launching a workflow using the protocol form
 developers:
   - Improve the DDBB lock in the method "_store". If Protocol._lock is locked, a nullcontext is used instead of another
     Protocol._lock context, which causes a permanent lock.
   - XmlMapper removed.
   - FlatMapper instanatiation centralized:
      New variable: SCIPION_MAPPER_USE_TEMPLATE. By default uses the template as it was now. If deacivated, instantiation happens on each iteration (less performant) but dev friendly
+  - Adding a parameter to launch jobs (e.g: bash)
 
 V3.6.0
 users:

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -2159,7 +2159,7 @@ class FormWindow(Window):
         elif resultAction == RESULT_RUN_ALL:
             if errors:
                 self.showInfo(errors)
-            self._close()
+            self.close()
             return
 
         # This code will happen when protocol is executed alone

--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -63,14 +63,14 @@ class StepExecutor:
 
     def runJob(self, log, programName, params,           
                numberOfMpi=1, numberOfThreads=1,
-               env=None, cwd=None):
+               env=None, cwd=None, executable=None):
         """ This function is a wrapper around runJob, 
         providing the host configuration. 
         """
         process.runJob(log, programName, params,
                        numberOfMpi, numberOfThreads, 
                        self.hostConfig,
-                       env=env, cwd=cwd, gpuList=self.getGpuList())
+                       env=env, cwd=cwd, gpuList=self.getGpuList(), executable=executable)
         
     def _getRunnable(self, steps, n=1):
         """ Return the n steps that are 'new' and all its

--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -299,7 +299,7 @@ class QueueStepExecutor(ThreadStepExecutor):
 
         logger.debug("Updated gpus ids rebase starting from 0: %s per thread" %self.gpuDict)
 
-    def runJob(self, log, programName, params, numberOfMpi=1, numberOfThreads=1, env=None, cwd=None):
+    def runJob(self, log, programName, params, numberOfMpi=1, numberOfThreads=1, env=None, cwd=None, executable=None):
         threadId = threading.current_thread().thId
         submitDict = dict(self.hostConfig.getQueuesDefault())
         submitDict.update(self.submitDict)

--- a/pyworkflow/utils/process.py
+++ b/pyworkflow/utils/process.py
@@ -42,7 +42,7 @@ from pyworkflow import Config
 # The job should be launched from the working directory!
 def runJob(log, programname, params,           
            numberOfMpi=1, numberOfThreads=1, 
-           hostConfig=None, env=None, cwd=None, gpuList=None):
+           hostConfig=None, env=None, cwd=None, gpuList=None, executable=None):
 
     command = buildRunCommand(programname, params, numberOfMpi, hostConfig,
                               env, gpuList=gpuList)
@@ -53,10 +53,10 @@ def runJob(log, programname, params,
     log.info("** Running command: **")
     log.info(greenStr(command))
 
-    return runCommand(command, env, cwd)
+    return runCommand(command, env=env, cwd=cwd, executable=executable)
         
 
-def runCommand(command, env=None, cwd=None):
+def runCommand(command, env=None, cwd=None, executable=None):
     """ Execute command with given environment env and directory cwd """
 
     # First let us create core dumps if in debug mode
@@ -69,7 +69,7 @@ def runCommand(command, env=None, cwd=None):
     # TODO: maybe have to set PBS_NODEFILE in case it is used by "command"
     # (useful for example with gnu parallel)
     check_call(command, shell=True, stdout=sys.stdout, stderr=sys.stderr,
-               env=env, cwd=cwd)
+               env=env, cwd=cwd, executable=executable)
     # It would be nice to avoid shell=True and calling buildRunCommand()...
 
     


### PR DESCRIPTION
* This occurs when a form is used to launch a subworkflow from the protocol. 