### PR TITLE
Step Queue executor: fix recursive use of cursors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ users:
   - Queue interoperability review:
     - jobs cancelled in the queue are detected in scipion
     - job and pids handling improved, pids = 0 when use queue for protocol rely on jobid
-    - locking the database to avoid concurrency when updating the protocols jobid
+    - Change Protocols Lock to Rlocks objects to avoid concurrency when updating the protocols jobid
   - add information in the protocol log regarding execution type (pid or jobid)f
   - Streaming protocols based on new streaming (generation steps) are resumable
   - Avoiding a double process when launching a workflow using the protocol form

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ users:
   - Queue interoperability review:
     - jobs cancelled in the queue are detected in scipion
     - job and pids handling improved, pids = 0 when use queue for protocol rely on jobid
-  - add information in the protocol log regarding execution type (pid or jobid)
+    - locking the database to avoid concurrency when updating the protocols jobid
+  - add information in the protocol log regarding execution type (pid or jobid)f
   - Streaming protocols based on new streaming (generation steps) are resumable
   - Avoiding a double process when launching a workflow using the protocol form
   - pyworkflowtest tests fixed

--- a/pyworkflow/project/project.py
+++ b/pyworkflow/project/project.py
@@ -782,12 +782,10 @@ class Project(object):
         finally:
             protocol.setSaved()
             protocol.runMode.set(MODE_RESTART)
-            protocol._store()
-            self._storeProtocol(protocol)
             protocol.makePathsAndClean()  # Create working dir if necessary
-            protocol.cleanExecutionAttributes() # Clean jobIds and Pid; otherwise, this would retain old job IDs and PIDs.
+            # Clean jobIds, Pid and StepsDone;
+            protocol.cleanExecutionAttributes()  # otherwise, this would retain old executions info
             protocol._store()
-            self._storeProtocol(protocol)
 
     def continueProtocol(self, protocol):
         """ This function should be called 

--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -311,9 +311,8 @@ class QueueStepExecutor(ThreadStepExecutor):
         submitDict['JOB_LOGS'] = os.path.join(getParentFolder(submitDict['JOB_SCRIPT']), submitDict['JOB_NAME'])
 
         jobid = _submit(self.hostConfig, submitDict, cwd, env)
-        with self.protocol._lock:  # Just in case we detect concurrency problem
-            self.protocol.appendJobId(jobid)  # append active jobs
-            self.protocol._store(self.protocol._jobId)
+        self.protocol.appendJobId(jobid)  # append active jobs
+        self.protocol._store(self.protocol._jobId)
 
         if (jobid is None) or (jobid == UNKNOWN_JOBID):
             logger.info("jobId is none therefore we set it to fail")
@@ -329,8 +328,7 @@ class QueueStepExecutor(ThreadStepExecutor):
             if wait < 300:
                 wait += 3
 
-        with self.protocol._lock:  # Just in case we detect concurrency problem
-            self.protocol.removeJobId(jobid)  # After completion, remove inactive jobs.
-            self.protocol._store(self.protocol._jobId)
+        self.protocol.removeJobId(jobid)  # After completion, remove inactive jobs.
+        self.protocol._store(self.protocol._jobId)
 
         return status

--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -311,9 +311,9 @@ class QueueStepExecutor(ThreadStepExecutor):
         submitDict['JOB_LOGS'] = os.path.join(getParentFolder(submitDict['JOB_SCRIPT']), submitDict['JOB_NAME'])
 
         jobid = _submit(self.hostConfig, submitDict, cwd, env)
-        # if self.protocol._lock: # Just in case we detect concurrency problem
-        self.protocol.appendJobId(jobid) # append active jobs
-        self.protocol._store(self.protocol._jobId)
+        with self.protocol._lock:  # Just in case we detect concurrency problem
+            self.protocol.appendJobId(jobid)  # append active jobs
+            self.protocol._store(self.protocol._jobId)
 
         if (jobid is None) or (jobid == UNKNOWN_JOBID):
             logger.info("jobId is none therefore we set it to fail")
@@ -329,8 +329,8 @@ class QueueStepExecutor(ThreadStepExecutor):
             if wait < 300:
                 wait += 3
 
-        # if self.protocol._lock: # Just in case we detect concurrency problem
-        self.protocol.removeJobId(jobid) # After completion, remove inactive jobs.
-        self.protocol._store(self.protocol._jobId)
+        with self.protocol._lock:  # Just in case we detect concurrency problem
+            self.protocol.removeJobId(jobid)  # After completion, remove inactive jobs.
+            self.protocol._store(self.protocol._jobId)
 
         return status


### PR DESCRIPTION
When sending the steps to the queue with thread parallelization, an error might occur due to the recursive use of cursors when updating the job IDs, as two steps could try to modify the database simultaneously. To handle this situation, we used a lock mechanism to ensure that only one thread can modify the database at a time, changing the Lock object to Rlock. Recursive locks allows a thread to acquire lock on same object more than one time, thus avoiding deadlock situation. This fixed the concurrency problems we had before.