### PR TITLE
JMK add option with call instead of check_call to allow fault for wsl

### DIFF
--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -61,14 +61,16 @@ class StepExecutor:
 
     def runJob(self, log, programName, params,           
                numberOfMpi=1, numberOfThreads=1,
-               env=None, cwd=None, executable=None):
+               env=None, cwd=None, executable=None,
+               allowFault=False):
         """ This function is a wrapper around runJob, 
         providing the host configuration. 
         """
         process.runJob(log, programName, params,
                        numberOfMpi, numberOfThreads, 
                        self.hostConfig,
-                       env=env, cwd=cwd, gpuList=self.getGpuList(), executable=executable)
+                       env=env, cwd=cwd, gpuList=self.getGpuList(), 
+                       executable=executable, allowFault=allowFault)
         
     def _getRunnable(self, steps, n=1):
         """ Return the n steps that are 'new' and all its

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -1514,6 +1514,8 @@ class Protocol(Step):
         if 'env' not in kwargs:
             kwargs['env'] = self._getEnviron()
 
+        kwargs['allowFault'] = kwargs.get('allowFault', False)
+
         self._stepsExecutor.runJob(self._log, program, arguments, **kwargs)
 
     def run(self):

--- a/pyworkflow/utils/process.py
+++ b/pyworkflow/utils/process.py
@@ -42,7 +42,8 @@ from pyworkflow import Config
 # The job should be launched from the working directory!
 def runJob(log, programname, params,           
            numberOfMpi=1, numberOfThreads=1, 
-           hostConfig=None, env=None, cwd=None, gpuList=None, executable=None):
+           hostConfig=None, env=None, cwd=None, gpuList=None, 
+           executable=None, allowFault=False):
 
     command = buildRunCommand(programname, params, numberOfMpi, hostConfig,
                               env, gpuList=gpuList)
@@ -53,8 +54,9 @@ def runJob(log, programname, params,
     log.info("** Running command: **")
     log.info(greenStr(command))
 
-    return runCommand(command, env=env, cwd=cwd, executable=executable)
-        
+    return runCommand(command, env=env, cwd=cwd, executable=executable, 
+                      allowFault=allowFault)
+
 
 def runCommand(command, env=None, cwd=None, executable=None, allowFault=False):
     """ Execute command with given environment env and directory cwd """

--- a/pyworkflow/utils/process.py
+++ b/pyworkflow/utils/process.py
@@ -32,7 +32,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 import sys
-from subprocess import check_call
+from subprocess import check_call, call
 import psutil
 
 from .utils import greenStr
@@ -56,7 +56,7 @@ def runJob(log, programname, params,
     return runCommand(command, env=env, cwd=cwd, executable=executable)
         
 
-def runCommand(command, env=None, cwd=None, executable=None):
+def runCommand(command, env=None, cwd=None, executable=None, allowFault=False):
     """ Execute command with given environment env and directory cwd """
 
     # First let us create core dumps if in debug mode
@@ -68,8 +68,13 @@ def runCommand(command, env=None, cwd=None, executable=None):
 
     # TODO: maybe have to set PBS_NODEFILE in case it is used by "command"
     # (useful for example with gnu parallel)
-    check_call(command, shell=True, stdout=sys.stdout, stderr=sys.stderr,
-               env=env, cwd=cwd, executable=executable)
+    if not allowFault:
+        # normal behaviour
+        check_call(command, shell=True, stdout=sys.stdout, stderr=sys.stderr,
+                   env=env, cwd=cwd, executable=executable)
+    else:
+        call(command, shell=True, stdout=sys.stdout, stderr=sys.stderr,
+             env=env, cwd=cwd, executable=executable)        
     # It would be nice to avoid shell=True and calling buildRunCommand()...
 
     


### PR DESCRIPTION
This option allows protocols that close programs in wsl with segfaults to still finish rather than raising errors