### PR TITLE
Fix: second argument provided

### DIFF
--- a/pyworkflow/gui/project/viewprotocols_extra.py
+++ b/pyworkflow/gui/project/viewprotocols_extra.py
@@ -504,7 +504,7 @@ class ProtocolTreeConfig:
 
             except Exception as e:
                 print('Failed to read settings. The reported error was:\n  %s\n'
-                      'To solve it, fix %s and run again.' % e)
+                      'To solve it, fix %s and run again.' % (e, pluginName))
 
         # Clean empty sections
         cls._hideEmptySections(protocols)


### PR DESCRIPTION
Pyworkflow version:
```
Name: scipion-pyworkflow
Version: 3.8.0
Summary: Simple workflow platform used in scientific applications, initially developed within the Scipion framework for image processing in Electron Microscopy.
Home-page: https://github.com/scipion-em/scipion-pyworkflow
Author: J.M. De la Rosa Trevin, Roberto Marabini, Grigory Sharov, Josue Gomez Blanco, Pablo Conesa, Yunior Fonseca Reyna
Author-email: delarosatrevin@scilifelab.se, roberto@cnb.csic.es, gsharov@mrc-lmb.cam.ac.uk, josue.gomez-blanco@mcgill.ca, pconesa@cnb.csic.es, fonsecareyna@cnb.csic.es
License: 
Location: /data/relocated/miniconda/envs/scipion3/lib/python3.8/site-packages
Requires: bibtexparser, configparser, distro, importlib-metadata, matplotlib, numpy, pillow, psutil, requests, tkcolorpicker
Required-by: scipion-em
```
When trying to open any project, I was getting:
```
Traceback (most recent call last):
  File "/home/msalinas/Documents/miniconda/envs/scipion3/lib/python3.8/site-packages/pyworkflow/apps/pw_project.py", line 111, in <module>
    openProject(sys.argv[1])
  File "/home/msalinas/Documents/miniconda/envs/scipion3/lib/python3.8/site-packages/pyworkflow/apps/pw_project.py", line 92, in openProject
    projWindow = ProjectWindow(projPath)
  File "/home/msalinas/Documents/miniconda/envs/scipion3/lib/python3.8/site-packages/pyworkflow/gui/project/project.py", line 128, in __init__
    self.switchView(VIEW_PROTOCOLS)
  File "/home/msalinas/Documents/miniconda/envs/scipion3/lib/python3.8/site-packages/pyworkflow/gui/project/base.py", line 147, in switchView
    self.viewWidget = self.viewFuncs[newView](self.footer, self)
  File "/home/msalinas/Documents/miniconda/envs/scipion3/lib/python3.8/site-packages/pyworkflow/gui/project/viewprotocols.py", line 98, in __init__
    self.protCfg = self.getCurrentProtocolView()
  File "/home/msalinas/Documents/miniconda/envs/scipion3/lib/python3.8/site-packages/pyworkflow/gui/project/viewprotocols.py", line 599, in getCurrentProtocolView
    if currentView in self.getProtocolViews():
  File "/home/msalinas/Documents/miniconda/envs/scipion3/lib/python3.8/site-packages/pyworkflow/gui/project/viewprotocols.py", line 589, in getProtocolViews
    self._loadProtocols()
  File "/home/msalinas/Documents/miniconda/envs/scipion3/lib/python3.8/site-packages/pyworkflow/gui/project/viewprotocols.py", line 616, in _loadProtocols
    self._protocolViews = ProtocolTreeConfig.load(self.project.getDomain(),
  File "/home/msalinas/Documents/miniconda/envs/scipion3/lib/python3.8/site-packages/pyworkflow/gui/project/viewprotocols_extra.py", line 506, in load
    print('Failed to read settings. The reported error was:\n  %s\n'
TypeError: not enough arguments for format string
```
It makes sense since there was only one variable provided for the string format.

Should be fixed now.