### PR TITLE
Using absolute path for absolute symlinking

### DIFF
--- a/pyworkflow/utils/path.py
+++ b/pyworkflow/utils/path.py
@@ -292,10 +292,11 @@ def createAbsLink(source, dest):
     """ Creates a link to a given file path"""
     if os.path.islink(dest):
         os.remove(dest)
-        
+
     if os.path.exists(dest):
         raise Exception('Destination %s os.path.exists and is not a link' % dest)
-
+    
+    source = os.path.abspath(source)
     os.symlink(source, dest)
 
 


### PR DESCRIPTION
Creating an absolute symlink in the creatAbsLink function. Otherwise, the link may be created relative to the CWD