### PR TITLE
bibtex parser fix

### DIFF
--- a/pyworkflow/utils/utils.py
+++ b/pyworkflow/utils/utils.py
@@ -498,7 +498,9 @@ class LazyDict(object):
 def parseBibTex(bibtexStr):
     """ Parse a bibtex file and return a dictionary. """
 
-    return bibtexparser.loads(bibtexStr).entries_dict
+    return bibtexparser.loads(bibtexStr,
+                              parser=bibtexparser.bparser.BibTexParser(common_strings=True)
+                              ).entries_dict
 
 
 


### PR DESCRIPTION
We have a lot of references with keys like: `month = may`. Apparently, such definition is not correct (https://github.com/sciunto-org/python-bibtexparser/issues/222#issuecomment-427621694). 

In Scipion methods tab you will get:
```
ERROR generating methods info: 'may'
Could not load all methods:'may'
```

Instead of replacing `may` with `{may}` in all plugins the fix suggested here sets an extra option to the parser.