### PR TITLE
Change exception class

### DIFF
--- a/pyworkflow/plugin.py
+++ b/pyworkflow/plugin.py
@@ -508,7 +508,7 @@ class Domain:
 
         raiseMsg = "%s\n %s\n%s\n" % (msgStr, calling, hint)
         if doRaise:
-            raise Exception("\n\n" + raiseMsg)
+            raise ImportError("\n\n" + raiseMsg)
         else:
             logger.info(raiseMsg)
 


### PR DESCRIPTION
Raising a generic `Exception` class eliminates the possibility for anyone using this method of capturing a precise execption type in their code.

As this method aims to handle both `ImportError` and `ModuleNotFound` exceptions, and `ImportError` is parent for `ModuleNotFound`, raising `ImportError` seems like a good enough choice for taking into account both cases at once.