### PR TITLE
fix error when host.conf hasn't got any QUEUE variables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,8 +6,10 @@ V3.10.6:
        versatile way to have a mpi command only for some plugins. Example:
        PARALLEL_COMMAND_RELION=mpirun.relion -np %%(JOB_NODES)d --map-by node %%(COMMAND)s
        NOTE: in this config file, %_ (valid and needed in host.conf) should be replaced by %%
+  - GPU Ids are automatically annonimized (0-len(GPUs)) when using queues
   developers:
   - Adding a Streaming section in ProtStreamingBase
+  - runJob call without %(GPU)s will not reserve GPU slots anymore.
    
 V3.10.5: cancel usage of SCIPION_PROJECT in the host template
 V3.10.4: hotfix: Parallelization with GPUs is fixed and step queue executor fixed with the new implementation.

--- a/pyworkflow/constants.py
+++ b/pyworkflow/constants.py
@@ -79,6 +79,10 @@ PLUGIN_MODULE_VAR = 'PLUGIN_MODULE'
 QUEUE_FOR_JOBS = 'QUEUE_FOR_JOBS'
 
 
+# Launching constants
+RUN_JOB_GPU_PARAM = 'GPU' # Param name to "place" GPU ids used to build a run command.
+RUN_JOB_GPU_PARAM_SEARCH = "%("+ RUN_JOB_GPU_PARAM +")s"
+
 # FONT
 SCIPION_DEFAULT_FONT_SIZE = 10
 

--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -39,7 +39,7 @@ import os
 
 import pyworkflow.utils.process as process
 from pyworkflow.utils.path import getParentFolder, removeExt
-from pyworkflow.constants import PLUGIN_MODULE_VAR
+from pyworkflow.constants import PLUGIN_MODULE_VAR, RUN_JOB_GPU_PARAM_SEARCH
 from . import constants as cts
 
 from .launch import _submit, UNKNOWN_JOBID, _checkJobStatus
@@ -72,7 +72,14 @@ class StepExecutor:
         process.runJob(log, programName, params,
                        numberOfMpi, numberOfThreads, 
                        self.hostConfig,
-                       env=env, cwd=cwd, gpuList=self.getGpuList(), executable=executable,context=self.protocol.getSubmitDict())
+                       env=env, cwd=cwd, gpuList=self._getGPUListFromCommand(programName, params), executable=executable,context=self.protocol.getSubmitDict())
+
+    def _getGPUListFromCommand(self, program, params):
+        """ Returns the list of GPUs if the program or the params have the GPU placeholder %(GPU)s """
+        if RUN_JOB_GPU_PARAM_SEARCH in params or RUN_JOB_GPU_PARAM_SEARCH in program:
+            return self.getGpuList()
+        else:
+            []
 
     def _getRunnable(self, steps, n=1):
         """ Return the n steps that are 'new' and all its
@@ -436,7 +443,7 @@ class QueueStepExecutor(ThreadStepExecutor):
 
         submitDict['JOB_COMMAND'] = process.buildRunCommand(programName, params, numberOfMpi,
                                                             self.hostConfig, env,
-                                                            gpuList=self.getGpuList(),
+                                                            gpuList=self._getGPUListFromCommand(programName, params),
                                                             context=submitDict)
 
 

--- a/pyworkflow/utils/process.py
+++ b/pyworkflow/utils/process.py
@@ -37,7 +37,7 @@ import psutil
 
 from .utils import greenStr
 from pyworkflow import Config
-from pyworkflow.constants import PLUGIN_MODULE_VAR, PARALLEL_COMMAND_VAR
+from pyworkflow.constants import PLUGIN_MODULE_VAR, PARALLEL_COMMAND_VAR, RUN_JOB_GPU_PARAM
 
 
 # The job should be launched from the working directory!
@@ -86,10 +86,10 @@ def buildRunCommand(programname, params, numberOfMpi, hostConfig=None,
         params = ' '.join('"%s"' % p for p in params)
 
     if gpuList:
-        params = params % {'GPU': ' '.join(str(g) for g in gpuList)}
+        params = params % {RUN_JOB_GPU_PARAM: ' '.join(str(g) for g in gpuList)}
         if "CUDA_VISIBLE_DEVICES" in programname:
             sep = "," if len(gpuList) > 1 else ""
-            programname = programname % {'GPU': sep.join(str(g) for g in gpuList)}
+            programname = programname % {RUN_JOB_GPU_PARAM: sep.join(str(g) for g in gpuList)}
 
     prepend = '' if env is None else env.getPrepend()
 

--- a/pyworkflowtests/tests/test_protocol_execution.py
+++ b/pyworkflowtests/tests/test_protocol_execution.py
@@ -73,6 +73,13 @@ class TestProtocolExecution(pwtests.BaseTest):
         
         self.assertEqual(prot.endTime.get(), prot2.endTime.get())
 
+    def test_gpu_anonimization(self):
+
+        self.assertEqual(pwprot.anonimizeGPUs([0, 1, 2]),[0, 1, 2], "Anonimization of GPUs does not work")
+        self.assertEqual(pwprot.anonimizeGPUs([2, 1, 0]), [0, 1, 2], "Anonimization of GPUs does not work")
+        self.assertEqual(pwprot.anonimizeGPUs([2, 1, 2]), [0, 1, 0], "Anonimization of GPUs does not work")
+        self.assertEqual(pwprot.anonimizeGPUs([2, 1, 2, 4]), [0, 1, 0, 2], "Anonimization of GPUs does not work")
+
     def test_gpuSlots(self):
         """ Test gpu slots are properly composed in combination of threads"""
 


### PR DESCRIPTION
- GPU Ids are automatically annonimized (0-len(GPUs)) when using queues
  developers:
  - runJob call without %(GPU)s will not reserve GPU slots anymore.