### PR TITLE
add missing line break before mpi help

### DIFF
--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -1743,7 +1743,7 @@ class FormWindow(Window):
                         entry = self._createBoundEntry(procFrame, pwutils.Message.VAR_MPI)
                         entry.grid(row=r2, column=c2 + 1, padx=(0, 5), sticky='w')
 
-                        helpMessage += pwutils.Message.HELP_PARALLEL_MPI
+                        helpMessage += '\n' + pwutils.Message.HELP_PARALLEL_MPI
 
 
                 btnHelp = IconButton(procFrame, pwutils.Message.TITLE_COMMENT,


### PR DESCRIPTION
Without the fix, I get something strange with the threads help and MPI help joined together
![image](https://github.com/user-attachments/assets/e8e462e5-9a17-46fe-bedb-da1ae317ae13)

With the fix, it looks as it should
![image](https://github.com/user-attachments/assets/c5c883bd-dd6d-4e02-bcd3-dbd79c830532)
