### PR TITLE
Resume protocol does not start at first not finished but only on not finished

### DIFF
--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -1273,7 +1273,7 @@ class Protocol(Step):
         """
         if self.runMode == MODE_RESTART:
             self._prevSteps = []
-            return 0
+            return []
 
         self._prevSteps = self.loadSteps()
 

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -1287,7 +1287,7 @@ class Protocol(Step):
             if (not oldStep.isFinished() or newStep != oldStep
                     or not oldStep._postconditions()):
                 if pw.Config.debugOn():
-                    self.info("Starting at step %d" % i)
+                    self.info("Rerunning step %d" % i)
                     self.info("     Old step: %s, args: %s"
                               % (oldStep.funcName, oldStep.argsStr))
                     self.info("     New step: %s, args: %s"


### PR DESCRIPTION
Doing some tests, the changes should work when resuming the protocol in parallel, so the execution is not resumed on the not the first not finished step, but ONLY for those not finished steps.
Previously, higher ID steps would be restarted if a lower ID step failed even if those were finished. 