### PR TITLE
Fix queue step job ID unpacking from submit result

### DIFF
--- a/pyworkflow/protocol/executor.py
+++ b/pyworkflow/protocol/executor.py
@@ -490,26 +490,32 @@ class QueueStepExecutor(ThreadStepExecutor):
                                                             gpuList=self._getGPUListForCommand(programName, params),
                                                             context=submitDict)
 
-        jobid = _submit(self.hostConfig, submitDict, cwd, env)
-        self.protocol.appendJobId(jobid)  # append active jobs
-        self.protocol._store(self.protocol._jobId)
+        jobId, submitError = _submit(self.hostConfig, submitDict, cwd, env)
 
-        if (jobid is None) or (jobid == UNKNOWN_JOBID):
-            errorMsg = "Failed to submit to queue. JOBID is not valid. There's probably an error interacting with the queue."
+        if (jobId is None) or (jobId == UNKNOWN_JOBID):
+            errorMsg = (
+                "Failed to submit to queue. JOBID is not valid. "
+                "There's probably an error interacting with the queue."
+            )
+            if submitError:
+                errorMsg += " Submit error: %s" % submitError
             logger.info(errorMsg)
             raise Exception(errorMsg)
+
+        self.protocol.appendJobId(jobId)
+        self.protocol._store(self.protocol._jobId)
 
         status = cts.STATUS_RUNNING
         wait = 3
 
         # Check status while job running
         # REVIEW this to minimize the overhead in time put by this delay check
-        while _checkJobStatus(self.hostConfig, jobid) == cts.STATUS_RUNNING:
+        while _checkJobStatus(self.hostConfig, jobId) == cts.STATUS_RUNNING:
             time.sleep(wait)
             if wait < 300:
                 wait += 3
 
-        self.protocol.removeJobId(jobid)  # After completion, remove inactive jobs.
+        self.protocol.removeJobId(jobId)  # After completion, remove inactive jobs.
         self.protocol._store(self.protocol._jobId)
 
         return status

--- a/pyworkflow/protocol/launch.py
+++ b/pyworkflow/protocol/launch.py
@@ -249,7 +249,7 @@ def _checkJobStatus(hostConfig, jobid):
     logger.debug("Queue engine replied %s, variable JOB_DONE_REGEX has %s" % (out, jobDoneRegex))
     # If nothing is returned we assume job is no longer in queue and thus finished
     if out == "":
-        logger.warning("Empty response from queue system to job (%s)" % jobid)
+        logger.warning("Empty response from queue system to job (%s)", jobid)
         return STATUS_FINISHED
 
     # If some string is returned we use the JOB_DONE_REGEX variable (if present) to infer the status


### PR DESCRIPTION
QueueStepExecutor.runJob was storing the full result returned by _submit(), which is a tuple containing the job ID and the submit error. This caused the queue status checker to receive a tuple instead of the actual job ID.

When squeue returned an empty response, the warning message in _checkJobStatus failed while formatting the tuple, raising:

TypeError: not all arguments converted during string formatting

The fix unpacks the _submit() result properly, uses only the job ID for job tracking and status checks, and preserves the submit error for better failure reporting.