### PR TITLE
Update distro version to 1.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy==1.24.4; python_version == '3.8'
 numpy==1.26.1; python_version >= '3.9' # up to date on 11-2023. Careful. Xmipp is compiled against numpy!
 requests==2.31.0; python_version >= '3.8' # up to date on 11-2023
 tkcolorpicker2 # updated 06-2025
-distro<=1.8 # up to date on 11-2023
+distro<=1.9 # up to date on 11-2023
 importlib-metadata<=6.8.0 # up to date on 11-2023
 setuptools>=62.6
 pyperclip==1.9.0


### PR DESCRIPTION
Upgrading to the latest distro version (1.9.0) should break nothing, as it is backwards compatible, and it helps expanding compatibility with dependencies (like xmipp3-installer) which have their dependencies up to date.